### PR TITLE
Update LOAD_PATH so Puppet can find parent providers.

### DIFF
--- a/lib/puppet/provider/cs_colocation/crm.rb
+++ b/lib/puppet/provider/cs_colocation/crm.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.push(File.join(File.dirname(__FILE__), '..', '..', '..'))
 require 'puppet/provider/corosync'
 Puppet::Type.type(:cs_colocation).provide(:crm, :parent => Puppet::Provider::Corosync) do
   desc 'Specific provider for a rather specific type since I currently have no plan to

--- a/lib/puppet/provider/cs_order/crm.rb
+++ b/lib/puppet/provider/cs_order/crm.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.push(File.join(File.dirname(__FILE__), '..', '..', '..'))
 require 'puppet/provider/corosync'
 Puppet::Type.type(:cs_order).provide(:crm, :parent => Puppet::Provider::Corosync) do
   desc 'Specific provider for a rather specific type since I currently have no plan to

--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.push(File.join(File.dirname(__FILE__), '..', '..', '..'))
 require 'puppet/provider/corosync'
 Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Corosync) do
   desc 'Specific provider for a rather specific type since I currently have no

--- a/lib/puppet/provider/cs_property/crm.rb
+++ b/lib/puppet/provider/cs_property/crm.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.push(File.join(File.dirname(__FILE__), '..', '..', '..'))
 require 'puppet/provider/corosync'
 Puppet::Type.type(:cs_property).provide(:crm, :parent => Puppet::Provider::Corosync) do
   desc 'Specific provider for a rather specific type since I currently have no plan to


### PR DESCRIPTION
Puppet does not make parent providers avaible to Ruby's LOAD_PATH
when they are contained in modules that are plugin-synced to an agent.

I opened this ticket #15074 to explain the issue in Puppet.

This code updates all of the providers to append their lib
directory to Puppet's LOAD_PATH so that these modules will work
with pluginsync.
