### PR TITLE
Enable setting ms_metadata in cs_primitive

### DIFF
--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -161,7 +161,7 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Coro
     @property_hash[:metadata] = should
   end
 
-  def ms_medata=(should)
+  def ms_metadata=(should)
     @property_hash[:ms_metadata] = should
   end
 


### PR DESCRIPTION
Just a typo, but the bug makes it so that the ms metadata couldn't be updated for primitives.
