### PR TITLE
Validate that cs_primitive ms_metadata notify is true/false

### DIFF
--- a/lib/puppet/type/cs_primitive.rb
+++ b/lib/puppet/type/cs_primitive.rb
@@ -113,8 +113,14 @@ module Puppet
     newproperty(:ms_metadata) do
       desc "A hash of metadata for the master/slave primitive state."
 
+      munge do |value|
+        value['notify'] = String(value['notify']) unless value['notify'].nil?
+        value
+      end
+
       validate do |value|
         raise Puppet::Error, "Puppet::Type::Cs_Primitive: ms_metadata property must be a hash" unless value.is_a? Hash
+        raise Puppet::Error, "Puppet::Type::Cs_primitive: ms_metadata property 'notify' must be true/false" unless value['notify'].nil? or String(value['notify']) =~ /^(true|false)$/
       end
 
       defaultto Hash.new


### PR DESCRIPTION
If a puppet bool `true`/`false` is given, then the provider sees `notify=true` and `notify="true"` as being different and will try to update the primitive on each run.

This validates the `notify` meta and stringifies it for proper provider comparison.
