### PR TITLE
Add check/force online

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class corosync(
   $multicast_address  = 'UNSET',
   $unicast_addresses  = 'UNSET',
   $force_online       = false,
+  $check_standby      = false,
   $debug              = false,
 ) {
 
@@ -199,6 +200,16 @@ class corosync(
     unless  => 'grep START=yes /etc/default/corosync',
     require => Package['corosync'],
     before  => Service['corosync'],
+  }
+
+  if $check_standby == true {
+    # Throws a puppet error if node is on standby
+    exec { 'check_standby node':
+      command => 'echo "Node appears to be on standby" && false',
+      path    => [ '/bin', '/usr/bin', '/sbin', '/usr/sbin' ],
+      unless  => "crm node status|grep ${::hostname}-standby|grep 'value=\"off\"'",
+      require => Service['corosync'],
+    }
   }
 
   if $force_online == true {


### PR DESCRIPTION
When a node is put into standby, it's nice to be able to run puppet and put everything back right. The `force_online` parameter allows a corosync module user to depend on puppet to keep the world a bit more sane by making sure nodes are in standby.

Sometimes organizations may just want notifications when a node is put into standby, but not actually enforcing re-onlining it. The `check_standby` parameter can be enabled in this case.
