### PR TITLE
Adding corosync::reprobe

### DIFF
--- a/manifests/reprobe.pp
+++ b/manifests/reprobe.pp
@@ -1,0 +1,21 @@
+class corosync::reprobe {
+  exec { 'crm resource reprobe':
+    path        => ['/bin','/usr/bin','/sbin','/usr/sbin'],
+    refreshonly => true,
+  }
+  Cs_primitive <| |> {
+    notify => Exec['crm resource reprobe'],
+  }
+  Cs_colocation <| |> {
+    notify => Exec['crm resource reprobe'],
+  }
+  Cs_order <| |> {
+    notify => Exec['crm resource reprobe'],
+  }
+  Cs_group <| |> {
+    notify => Exec['crm resource reprobe'],
+  }
+  Cs_commit <| |> {
+    notify => Exec['crm resource reprobe'],
+  }
+}


### PR DESCRIPTION
This creates a class that can be notified any time the cluster needs to be reprobed, such as after creating new `cs_*` configuration.
