### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,5 @@
+2012-10-14 - Version 0.1.0
+- Added robustness for general corosync management (read the merges)
+- Added `cs_group` type
+- Added some testing
+- Generally tried to get on top of this thing.

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-corosync'
-version '0.0.1'
+version '0.1.0'
 source 'https://github.com/puppetlabs/puppetlabs-corosync.git'
 author 'puppetlabs'
 license 'APL 2.0'


### PR DESCRIPTION
- Added robustness for general corosync management (read the merges)
- Added `cs_group` type
- Added some testing
- Generally tried to get on top of this thing.
