### PR TITLE
Delete an existing cib to start fresh

### DIFF
--- a/lib/puppet/provider/cs_shadow/crm.rb
+++ b/lib/puppet/provider/cs_shadow/crm.rb
@@ -11,6 +11,11 @@ Puppet::Type.type(:cs_shadow).provide(:crm, :parent => Puppet::Provider::Corosyn
   end
 
   def sync(cib)
+    begin
+      crm('cib', 'delete', cib)
+    rescue => e
+      # If the CIB doesn't exist, we don't care.
+    end
     crm('cib', 'new', cib)
   end
 end


### PR DESCRIPTION
When configuring corosync resources from two hosts, the first host to run would create a CIB and cache its own changes. The second node would pick up on the first node's changes and add its own, but when puppet on the first node runs a second time it does not update the CIB for the second node's resources.

By deleting the CIB before starting the run, it will ensure that it is always fresh from the configuration of the whole cluster. (Note: `crm cib reset` did not seem to solve this problem.)
