### PR TITLE
Only change /etc/defaults for corosync startup on Debian platforms

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -189,12 +189,14 @@ class corosync(
     require => Package['corosync']
   }
 
-  exec { 'enable corosync':
-    command => 'sed -i s/START=no/START=yes/ /etc/default/corosync',
-    path    => [ '/bin', '/usr/bin' ],
-    unless  => 'grep START=yes /etc/default/corosync',
-    require => Package['corosync'],
-    before  => Service['corosync'],
+  if $::osfamily == 'Debian' {
+    exec { 'enable corosync':
+      command => 'sed -i s/START=no/START=yes/ /etc/default/corosync',
+      path    => [ '/bin', '/usr/bin' ],
+      unless  => 'grep START=yes /etc/default/corosync',
+      require => Package['corosync'],
+      before  => Service['corosync'],
+    }
   }
 
   if $check_standby == true {


### PR DESCRIPTION
We are using the module succesfully on CentOS 6.3 and as far as I can tell this is the only platform dependant bit of code.

I have isolated it using $::osfamily fact to make sure it only happend on Debian family distros.
