### PR TITLE
Puppet 3 compatibility

### DIFF
--- a/lib/puppet/provider/cs_commit/crm.rb
+++ b/lib/puppet/provider/cs_commit/crm.rb
@@ -2,8 +2,12 @@ require 'pathname'
 require Pathname.new(__FILE__).dirname.dirname.expand_path + 'corosync'
 
 Puppet::Type.type(:cs_commit).provide(:crm, :parent => Puppet::Provider::Corosync) do
-  commands :crm => 'crm'
   commands :crm_attribute => 'crm_attribute'
+  if Puppet::PUPPETVERSION.to_f < 3
+    commands :crm => 'crm'
+  else
+    has_command(:crm, 'crm') { environment :HOME => '/root' }
+  end
 
   def self.instances
     block_until_ready

--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -11,8 +11,12 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Coro
         better model since these values can be almost anything.'
 
   # Path to the crm binary for interacting with the cluster configuration.
-  commands :crm => 'crm'
   commands :crm_attribute => 'crm_attribute'
+  if Puppet::PUPPETVERSION.to_f < 3
+    commands :crm => 'crm'
+  else
+    has_command(:crm, 'crm') { environment :HOME => '/root' }
+  end
 
   def self.instances
 
@@ -21,7 +25,13 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Coro
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    if Puppet::PUPPETVERSION.to_f < 3
+      raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    else
+      raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd, nil, nil,
+        :custom_environment => { 'HOME' => '/root' }
+      )
+    end
     doc = REXML::Document.new(raw)
 
     # We are obtaining four different sets of data in this block.  We obtain

--- a/lib/puppet/provider/cs_shadow/crm.rb
+++ b/lib/puppet/provider/cs_shadow/crm.rb
@@ -2,8 +2,12 @@ require 'pathname'
 require Pathname.new(__FILE__).dirname.dirname.expand_path + 'corosync'
 
 Puppet::Type.type(:cs_shadow).provide(:crm, :parent => Puppet::Provider::Corosync) do
-  commands :crm => 'crm'
   commands :crm_attribute => 'crm_attribute'
+  if Puppet::PUPPETVERSION.to_f < 3
+    commands :crm => 'crm'
+  else
+    has_command(:crm, 'crm') { environment :HOME => '/root' }
+  end
 
   def self.instances
     block_until_ready

--- a/manifests/reprobe.pp
+++ b/manifests/reprobe.pp
@@ -18,6 +18,7 @@ class corosync::reprobe {
   exec { 'crm resource reprobe':
     path        => ['/bin','/usr/bin','/sbin','/usr/sbin'],
     refreshonly => true,
+    environment => 'HOME=/root',
   }
   Cs_primitive <| |> {
     notify => Exec['crm resource reprobe'],


### PR DESCRIPTION
`crm` fails if HOME is unset (it insists on loading `$HOME/.crm_history`).

I've added a conditional that explicitly sets `HOME=/root` if puppetversion >= 3.

Not sure if this is the right approach.

Tested on 2.6 and 3.0.
