### PR TITLE
Template compatibility Puppet 3.2

### DIFF
--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -10,13 +10,13 @@ totem {
   max_messages:                        20
   clear_node_high_bit:                 yes
   rrp_mode:                            none
-  secauth:                             <%= enable_secauth_real %>
-  threads:                             <%= threads_real %>
+  secauth:                             <%= @enable_secauth_real %>
+  threads:                             <%= @threads_real %>
   interface {
     ringnumber:  0
-    bindnetaddr: <%= bind_address_real %>
-    mcastaddr:   <%= multicast_address_real %>
-    mcastport:   <%= port_real %>
+    bindnetaddr: <%= @bind_address_real %>
+    mcastaddr:   <%= @multicast_address_real %>
+    mcastport:   <%= @port_real %>
   }
 }
 

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -10,18 +10,18 @@ totem {
   max_messages:                        20
   clear_node_high_bit:                 yes
   rrp_mode:                            none
-  secauth:                             <%= enable_secauth_real %>
-  threads:                             <%= threads_real %>
+  secauth:                             <%= @enable_secauth_real %>
+  threads:                             <%= @threads_real %>
   transport:                           udpu
   interface {
-<% unicast_addresses.each do |addr| -%>
+<% @unicast_addresses.each do |addr| -%>
     member {
       memberaddr: <%= addr %>
     }
 <% end -%>
     ringnumber:  0
-    bindnetaddr: <%= bind_address_real %>
-    mcastport:   <%= port_real %>
+    bindnetaddr: <%= @bind_address_real %>
+    mcastport:   <%= @port_real %>
   }
 }
 

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -1,4 +1,4 @@
 service {
-  name: <%= name %>
-  ver:  <%= version %>
+  name: <%= @name %>
+  ver:  <%= @version %>
 }


### PR DESCRIPTION
Puppet 3.2 complains when using local variables instead of instance variables when passing data from Puppet to ERB. This fix shouldn't have any impact.
