### PR TITLE
Allow ordering of cs_groups

### DIFF
--- a/lib/puppet/type/cs_order.rb
+++ b/lib/puppet/type/cs_order.rb
@@ -55,20 +55,39 @@ module Puppet
       [ @parameters[:cib] ]
     end
 
+    valid_resource_types = [:cs_primitive, :cs_group]
+    newparam(:resources_type) do
+      desc "String to specify which HA resource type is used for this order,
+        e.g. when you want to order groups (cs_group) instead of primitives.
+        Defaults to cs_primitive."
+
+      defaultto :cs_primitive
+      validate do |value|
+        valid_resource_types.include? value
+      end
+    end
+
     autorequire(:service) do
       [ 'corosync' ]
     end
 
-    autorequire(:cs_primitive) do
-      autos = []
+    valid_resource_types.each{ |possible_resource_type|
+      # We're generating autorequire blocks for all possible cs_ types because
+      # accessing the @parameters[:resources_type].value doesn't seem possible
+      # when the type is declared. Feel free to improve this.
+      autorequire(possible_resource_type) do
+        autos = []
+        resource_type = @parameters[:resources_type].value
+        if resource_type.to_sym == possible_resource_type.to_sym
+          autos << unmunge_cs_resourcename(@parameters[:first].should)
+          autos << unmunge_cs_resourcename(@parameters[:second].should)
+        end
 
-      autos << unmunge_cs_primitive(@parameters[:first].should)
-      autos << unmunge_cs_primitive(@parameters[:second].should)
+        autos
+      end
+    }
 
-      autos
-    end
-
-    def unmunge_cs_primitive(name)
+    def unmunge_cs_resourcename(name)
       name = name.split(':')[0]
       if name.start_with? 'ms_'
         name = name[3..-1]


### PR DESCRIPTION
Cs_order only supported ordering of cs_primitives, but groups can also be ordered in Pacemaker. To allow this, an extra parameter was added to the cs_order which allows you to specify you're dealing with groups. This way, autorequire works as you would expect.

Example:

```
cs_group {
    'group_name_1': ... ;
    'group_name_2': ... ;
}
cs_order {
    'o_g1_before_g2':
        first   => 'group_name_1',
        second  => 'group_name_2',
        resources_type => 'cs_group';
}
```
