### PR TITLE
more than two primitives per cs_colocation

### DIFF
--- a/lib/puppet/type/cs_colocation.rb
+++ b/lib/puppet/type/cs_colocation.rb
@@ -32,7 +32,7 @@ module Puppet
       def should=(value)
         super
         if value.is_a? Array
-          raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be a two value array." unless value.size == 2
+          raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be a two value array." unless value.size >= 2
           @should.sort!
         else
           raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be a two value array."


### PR DESCRIPTION
I added the possibility to use more than two primitives per cs_colocation resource. e.g.:

cs_colocation { "vip_with_ld_${name}":
  primitives => [ "vip_${vip}", "ldirectord_${name}", "nginx_${name}" ],
  ensure => present,
}

It's not really tested yet, but it works fine in my environment.
