### PR TITLE
added require=>Package['corosync'] to authkey file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,6 +157,7 @@ class corosync(
       owner   => 'root',
       group   => 'root',
       notify  => Service['corosync'],
+      require => Package['corosync'],
     }
   }
 


### PR DESCRIPTION
The /etc/corosync dir is created by package "corosync". If puppet decides to do the authkey file before the package (which can happen without dependency) the whole process goes south.

The require solves that problem.
