### PR TITLE
Added cs_property information to the read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,20 @@ cs_order { 'vip_before_service':
 
 Crosync Properties
 ------------------
+A few gloabal settings can be changed with the "cs_property" section.
+
 
 Disable STONITH if required.
 ```puppet
 cs_property { 'stonith-enabled' :
   value   => 'false',
+}
+```
+
+Change quorum policy 
+```
+cs_property { 'no-quorum-policy' :
+  value   => 'ignore',
 }
 ```
 


### PR DESCRIPTION
There are a few settings which we use and are not documented in the README.

I have added a quick note to these sections and removed a note about "STONITH" not being configurable.
