### PR TITLE
Changed osfamily check to include other operating systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,14 +208,23 @@ class corosync(
     require => Package['corosync']
   }
 
-  if $::osfamily == 'Debian' {
-    exec { 'enable corosync':
-      command => 'sed -i s/START=no/START=yes/ /etc/default/corosync',
-      path    => [ '/bin', '/usr/bin' ],
-      unless  => 'grep START=yes /etc/default/corosync',
-      require => Package['corosync'],
-      before  => Service['corosync'],
+  case $::osfamily {
+    'RedHat', 'CentOS': {
+      exec { 'enable corosync':
+        require => Package['corosync'],
+        before  => Service['corosync'],
+      }
     }
+    /^(Debian|Ubuntu)$/: {
+      exec { 'enable corosync':
+        command => 'sed -i s/START=no/START=yes/ /etc/default/corosync',
+        path    => [ '/bin', '/usr/bin' ],
+        unless  => 'grep START=yes /etc/default/corosync',
+        require => Package['corosync'],
+        before  => Service['corosync'],
+      }
+    }
+    default: {}
   }
 
   if $check_standby == true {


### PR DESCRIPTION
Changed the osfamily fact check.  This would fail on CentOS systems and try to run the Debian enable corosync actions.  I've tested this by adding it to a CentOS machine (which prompted this) and the fact is now accurately reported and actions applied.
