### PR TITLE
Actually enable corosync service in RedHat

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,8 +235,12 @@ class corosync(
   case $::osfamily {
     'RedHat': {
       exec { 'enable corosync':
-        require => Package['corosync'],
-        before  => Service['corosync'],
+        command     => 'chkconfig corosync on',
+        path        => [ '/bin', '/sbin', '/usr/bin' ],
+        unless      => 'chkconfig --list corosync | grep "3:on"',
+        environment => 'LANG=C',
+        require     => Package['corosync'],
+        before      => Service['corosync'],
       }
     }
     'Debian': {


### PR DESCRIPTION
9f1c2fb introduces support for enabling the service in redhat but it is not functional. It lacks the command to accomplish it!
