### PR TITLE
Fixed 'enable corosync' on CentOS as there is no 'enable' on CentOS

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -233,13 +233,6 @@ class corosync(
   }
 
   case $::osfamily {
-    'RedHat': {
-      exec { 'enable corosync':
-        command => '/bin/true',
-        require => Package['corosync'],
-        before  => Service['corosync'],
-      }
-    }
     'Debian': {
       exec { 'enable corosync':
         command => 'sed -i s/START=no/START=yes/ /etc/default/corosync',


### PR DESCRIPTION
RedHat/CentOS 6 has no "enable" and "disable". RedHat/CentOS 6 uses chkconfig, nowever as service corosync enable => true is set, there is no need to enable the service. 
