### PR TITLE
Allow multiple operations with the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ cs_primitive { 'nginx_service':
 }
 ```
 
+Note: Operations with the same names should be declared as an Array. Example:
+```puppet
+cs_primitive { 'pgsql_service':
+  primitive_class => 'ocf',
+  primitive_type  => 'pgsql',
+  provided_by     => 'heartbeat',
+  operations      => {
+    'monitor' => [
+      { 'interval' => '10s', 'timeout' => '30s' },
+      { 'interval' => '5s', 'timeout' => '30s', 'role' => 'Master' },
+    ],
+    'start'   => { 'interval' => '0', 'timeout' => '30s', 'on-fail' => 'restart' }
+  },
+}
+```
+
+
 Configuring locations
 -----------------------
 

--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -47,14 +47,24 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
     if ! e.elements['operations'].nil?
       e.elements['operations'].each_element do |o|
         valids = o.attributes.reject do |k,v| k == 'id' end
-        hash[:operations][valids['name']] = {}
+        currentop = {}
         valids.each do |k,v|
-          hash[:operations][valids['name']][k] = v if k != 'name'
+          currentop[k] = v if k != 'name'
         end
         if ! o.elements['instance_attributes'].nil?
           o.elements['instance_attributes'].each_element do |i|
-            hash[:operations][valids['name']][(i.attributes['name'])] = i.attributes['value']
+            currentop[(i.attributes['name'])] = i.attributes['value']
           end
+        end
+        if hash[:operations][valids['name']].instance_of?(Hash)
+          # There is already an operation with the same name, change to Array
+          hash[:operations][valids['name']] = [hash[:operations][valids['name']]]
+        end
+        if hash[:operations][valids['name']].instance_of?(Array)
+          # Append to an existing list
+          hash[:operations][valids['name']] += [currentop]
+        else
+          hash[:operations][valids['name']] = currentop
         end
       end
     end
@@ -192,9 +202,11 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
       unless @property_hash[:operations].empty?
         operations = ''
         @property_hash[:operations].each do |o|
-          operations << "op #{o[0]} "
-          o[1].each_pair do |k,v|
-            operations << "#{k}=#{v} "
+          [o[1]].flatten.each do |o2|
+            operations << "op #{o[0]} "
+            o2.each_pair do |k,v|
+              operations << "#{k}=#{v} "
+            end
           end
         end
       end

--- a/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
@@ -31,6 +31,7 @@ describe Puppet::Type.type(:cs_primitive).provider(:crm) do
                     <nvpair id="nginx-monitor-15s-instance_attributes-OCF_CHECK_LEVEL" name="OCF_CHECK_LEVEL" value="10"/>
                   </instance_attributes>
                 </op>
+                <op id="nginx-monitor-5s" interval="5" name="monitor" on-fail="standby" timeout="10" role="Master"/>
               </operations>
             </primitive>
           </resources>
@@ -89,7 +90,10 @@ describe Puppet::Type.type(:cs_primitive).provider(:crm) do
 
       it 'has an operations property corresponding to <operations>' do
         expect(instance.operations).to eq({
-          "monitor" => {"interval" => "15", "timeout" => "10", "on-fail" => "standby", "OCF_CHECK_LEVEL" => "10"},
+          "monitor" => [
+            {"interval" => "15", "timeout" => "10", "on-fail" => "standby", "OCF_CHECK_LEVEL" => "10"},
+            {"interval" => "5", "timeout" => "10", "on-fail" => "standby", "role" => "Master"}
+          ],
           "start" => {"interval" => "0", "timeout" => "60"},
           "stop" => {"interval" => "0", "timeout" => "40"},
         })


### PR DESCRIPTION
In some cases (like [http://clusterlabs.org/wiki/PgSQL_Replicated_Cluster]) severral operations with the same name are necessary.
