### PR TITLE
(MODULES-1503) Fix parameter quotes

### DIFF
--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -201,7 +201,7 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
       unless @property_hash[:parameters].empty?
         parameters = 'params '
         @property_hash[:parameters].each_pair do |k,v|
-          parameters << "#{k}=#{v} "
+          parameters << "#{k}=\"#{v}\" "
         end
       end
       unless @property_hash[:utilization].empty?

--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -240,7 +240,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
       unless @property_hash[:parameters].empty?
         parameters = []
         @property_hash[:parameters].each_pair do |k,v|
-          parameters << "#{k}=#{v}"
+          parameters << "#{k}=\"#{v}\""
         end
       end
       unless @property_hash[:utilization].empty?

--- a/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
@@ -166,7 +166,7 @@ describe Puppet::Type.type(:cs_primitive).provider(:crm) do
 
     it 'sets parameters' do
       instance.parameters = {'fluffyness' => '12'}
-      expect_update(/params fluffyness=12/)
+      expect_update(/params fluffyness="12"/)
       instance.flush
     end
 

--- a/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
@@ -193,7 +193,7 @@ describe Puppet::Type.type(:cs_primitive).provider(:pcs) do
 
     it 'sets parameters' do
       instance.parameters = {'fluffyness' => '12'}
-      expect_update(/(pcs resource op remove|fluffyness=12)/)
+      expect_update(/(pcs resource op remove|fluffyness="12")/)
       instance.flush
     end
 


### PR DESCRIPTION
The cs_primitive providers have a :parameters property where the value
of a parameter could be a list of values. They therefore must be quoted
so that the whole list is associated with the key of the parameter
during the flush operation. This patch adds the quotes and updates the
unit tests for them.
