### PR TITLE
MODULES-1547 - Strict variable support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 spec/fixtures
 .bundle
+pkg

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,90 +82,45 @@
 # Copyright 2012, Puppet Labs, LLC.
 #
 class corosync(
-  $enable_secauth     = 'UNSET',
-  $authkey_source     = 'file',
-  $authkey            = '/etc/puppet/ssl/certs/ca.pem',
-  $threads            = 'UNSET',
-  $port               = 'UNSET',
-  $bind_address       = 'UNSET',
-  $multicast_address  = 'UNSET',
-  $unicast_addresses  = 'UNSET',
-  $force_online       = false,
-  $check_standby      = false,
-  $debug              = false,
-  $rrp_mode           = 'none',
-  $ttl                = false,
-  $packages           = ['corosync', 'pacemaker'],
-) {
+  $enable_secauth    = $::corosync::params::enable_secauth,
+  $authkey_source    = $::corosync::params::authkey_source,
+  $authkey           = $::corosync::params::authkey,
+  $threads           = $::corosync::params::threads,
+  $port              = $::corosync::params::port,
+  $bind_address      = $::corosync::params::bind_address,
+  $multicast_address = $::corosync::params::multicast_address,
+  $unicast_addresses = $::corosync::params::unicast_addresses,
+  $force_online      = $::corosync::params::force_online,
+  $check_standby     = $::corosync::params::check_standby,
+  $debug             = $::corosync::params::debug,
+  $rrp_mode          = $::corosync::params::rrp_mode,
+  $ttl               = $::corosync::params::ttl,
+  $packages          = $::corosync::params::packages,
+) inherits ::corosync::params {
 
-  # Making it possible to provide data with parameterized class declarations or
-  # Console.
-  $threads_real = $threads ? {
-    'UNSET' => $::threads ? {
-      undef   => $::processorcount,
-      default => $::threads,
-    },
-    default => $threads,
+  if ! is_bool($enable_secauth) {
+    validate_re($enable_secauth, '^(on|off)$')
   }
+  validate_re($authkey_source, '^(file|string)$')
+  validate_bool($force_online)
+  validate_bool($check_standby)
+  validate_bool($debug)
 
-  $port_real = $port ? {
-    'UNSET' => $::port ? {
-      undef   => '5405',
-      default => $::port,
-    },
-    default => $port,
-  }
-
-  $bind_address_real = $bind_address ? {
-    'UNSET' => $::bind_address ? {
-      undef   => $::ipaddress,
-      default => $::bind_address,
-    },
-    default => $bind_address,
-  }
-
-  $unicast_addresses_real = $unicast_addresses ? {
-    'UNSET' => $::unicast_addresses ? {
-      undef   => 'UNSET',
-      default => $::unicast_addresses
-    },
-    default => $unicast_addresses
-  }
-  if $unicast_addresses_real == 'UNSET' {
+  if $unicast_addresses == 'UNSET' {
     $corosync_conf = "${module_name}/corosync.conf.erb"
   } else {
     $corosync_conf = "${module_name}/corosync.conf.udpu.erb"
   }
 
-  # We use an if here instead of a selector since we need to fail the catalog if
-  # this value is provided.  This is emulating a required variable as defined in
-  # parameterized class.
-
   # $multicast_address is NOT required if $unicast_address is provided
-  if $multicast_address == 'UNSET' and $unicast_addresses_real == 'UNSET' {
-    if ! $::multicast_address {
+  if $multicast_address == 'UNSET' and $unicast_addresses == 'UNSET' {
       fail('You must provide a value for multicast_address')
-    } else {
-      $multicast_address_real = $::multicast_address
-    }
-  } else {
-    $multicast_address_real = $multicast_address
   }
 
-  if $enable_secauth == 'UNSET' {
-    case $::enable_secauth {
-      true:  { $enable_secauth_real = 'on' }
-      false: { $enable_secauth_real = 'off' }
-      undef:   { $enable_secauth_real = 'on' }
-      '':      { $enable_secauth_real = 'on' }
-      default: { validate_re($::enable_secauth, '^true$|^false$') }
-    }
-  } else {
-      case $enable_secauth {
-        true:   { $enable_secauth_real = 'on' }
-        false:  { $enable_secauth_real = 'off' }
-        default: { fail('The enable_secauth class parameter requires a true or false boolean') }
-      }
+  case $enable_secauth {
+    true:    { $enable_secauth_real = 'on' }
+    false:   { $enable_secauth_real = 'off' }
+    default: { $enable_secauth_real = $enable_secauth }
   }
 
   # Using the Puppet infrastructure's ca as the authkey, this means any node in
@@ -195,9 +150,7 @@ class corosync(
           require => Package['corosync'],
         }
       }
-      default: {
-        fail("authkey_source must be either 'file' or 'string'.")
-      }
+      default: {}
     }
   }
 
@@ -245,7 +198,7 @@ class corosync(
     default: {}
   }
 
-  if $check_standby == true {
+  if $check_standby {
     # Throws a puppet error if node is on standby
     exec { 'check_standby node':
       command => 'echo "Node appears to be on standby" && false',
@@ -255,7 +208,7 @@ class corosync(
     }
   }
 
-  if $force_online == true {
+  if $force_online {
     exec { 'force_online node':
       command => 'crm node online',
       path    => [ '/bin', '/usr/bin', '/sbin', '/usr/sbin' ],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,16 @@
+class corosync::params {
+  $enable_secauth    = true
+  $authkey_source    = 'file'
+  $authkey           = '/etc/puppet/ssl/certs/ca.pem'
+  $threads           = $::processorcount
+  $port              = '5405'
+  $bind_address      = $::ipaddress
+  $multicast_address = 'UNSET'
+  $unicast_addresses = 'UNSET'
+  $force_online      = false
+  $check_standby     = false
+  $debug             = false
+  $rrp_mode          = 'none'
+  $ttl               = false
+  $packages          = ['corosync', 'pacemaker']
+}

--- a/metadata.json
+++ b/metadata.json
@@ -2,19 +2,15 @@
   "name": "puppetlabs-corosync",
   "version": "0.6.0",
   "author": "Puppet Labs",
-  "summary": "Sets up and manages Corosync",
+  "summary": "This module is a set of manifests and types/providers for quickly setting up highly available clusters using Corosync",
   "license": "Apache License, Version 2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-corosync",
   "project_page": "https://github.com/puppetlabs/puppetlabs-corosync",
-  "issues_url": null,
+  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "types": [
   
   ],
-  "description": "This module is a set of manifests and types/providers for quickly setting up highly available clusters using Corosync",
   "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.1"
-    }
+    {"name":"puppetlabs/stdlib","version_requirement":"4.x"}
   ]
 }

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'corosync', :type => :class do
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :processorcount => '3',
+        :ipaddress      => '127.0.0.1',
+        :osfamily       => 'Debian'
+      }
+    end
+    let :params do
+      { :multicast_address => '239.1.1.2' }
+    end
+    it { is_expected.to compile }
+  end
+end


### PR DESCRIPTION
Cleaned up code to not use miscellaneous global variables. Converted
code to use the `params` pattern. Added a _very_ basic unit test to make
sure it was compiling with strict variables. Bumped the stdlib
dependency to 4.x so I could do additional validation.
