### PR TITLE
Fixed regression in refactoring

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,10 +166,10 @@ class corosync(
   # - $unicast_addresses
   # - $multicast_address
   # - $debug
-  # - $bind_address_real
-  # - $port_real
+  # - $bind_address
+  # - $port
   # - $enable_secauth_real
-  # - $threads_real
+  # - $threads
   # - $token
   file { '/etc/corosync/corosync.conf':
     ensure  => file,

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -11,16 +11,16 @@ totem {
   clear_node_high_bit:                 yes
   rrp_mode:                            <%= @rrp_mode %>
   secauth:                             <%= @enable_secauth_real %>
-  threads:                             <%= @threads_real %>
-<% [@bind_address_real].flatten.each_index do |i| -%>
+  threads:                             <%= @threads %>
+<% [@bind_address].flatten.each_index do |i| -%>
   interface {
     ringnumber:  <%= i %>
-    bindnetaddr: <%= [@bind_address_real].flatten[i] %>
-<% if [@multicast_address_real].flatten[i] == 'broadcast' -%>
+    bindnetaddr: <%= [@bind_address].flatten[i] %>
+<% if [@multicast_address].flatten[i] == 'broadcast' -%>
     broadcast:   yes
 <% else -%>
-    mcastaddr:   <%= [@multicast_address_real].flatten[i] %>
-    mcastport:   <%= [@port_real].flatten[i] %>
+    mcastaddr:   <%= [@multicast_address].flatten[i] %>
+    mcastport:   <%= [@port].flatten[i] %>
 <% end -%>
 <% if @ttl -%>
     ttl:         <%= @ttl %>

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -11,7 +11,7 @@ totem {
   clear_node_high_bit:                 yes
   rrp_mode:                            <%= @rrp_mode %>
   secauth:                             <%= @enable_secauth_real %>
-  threads:                             <%= @threads_real %>
+  threads:                             <%= @threads %>
   transport:                           udpu
   interface {
 <% @unicast_addresses.each do |addr| -%>
@@ -20,8 +20,8 @@ totem {
     }
 <% end -%>
     ringnumber:  0
-    bindnetaddr: <%= @bind_address_real %>
-    mcastport:   <%= @port_real %>
+    bindnetaddr: <%= @bind_address %>
+    mcastport:   <%= @port %>
 <% if @ttl -%>
     ttl:         <%= @ttl %>
 <% end -%>


### PR DESCRIPTION
The refactoring in upstream caused the templates to become invalid: 

Affected machine config diff after changing:

```
@@ -11,7 +11,7 @@
   clear_node_high_bit:                 yes
   rrp_mode:                            none
   secauth:                             on
-  threads:                             4
+  threads:
   transport:                           udpu
   interface {
     member {
@@ -21,8 +21,8 @@
       memberaddr: db02.t5.mellon.tools.cgn.travian.info
     }
     ringnumber:  0
-    bindnetaddr: 10.64.16.168
-    mcastport:   5405
+    bindnetaddr:
+    mcastport:
     ttl:         1
   }
 }
```

This fix tries to fix the issues introduced by the regression, alrought certain changes are not 100% backward compatible (e.g. ::threadcount vs. ::processors). 

This fix is intested, but I think the whole refactoring process should be reviewed to verify correctness of the manifest.
