### PR TITLE
Managing pcs service on RHEL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,12 @@
 #   addition to the corosync service.
 #   Defaults to false, except on Ubuntu 14.04+ where it defaults to true.
 #
+# [*manage_pcsd_service*]
+#   Whether the module should try to manage the pcsd service in addition to the
+#   corosync service.
+#   pcsd service is the GUI and the remote configuration interface.
+#   Defaults to false
+#
 # [*cluster_name*]
 #   This specifies the name of cluster and it's used for automatic
 #   generating of multicast address.
@@ -195,6 +201,7 @@ class corosync(
   $token_retransmits_before_loss_const = $::corosync::params::token_retransmits_before_lost_const,
   $compatibility                       = $::corosync::params::compatibility,
   $manage_pacemaker_service            = $::corosync::params::manage_pacemaker_service,
+  $manage_pcsd_service                 = false,
   $cluster_name                        = $::corosync::params::cluster_name,
   $join                                = $::corosync::params::join,
   $consensus                           = $::corosync::params::consensus,
@@ -340,6 +347,13 @@ class corosync(
     if $_package_pcs {
       package { 'pcs':
         ensure => $_version_pcs,
+      }
+      if $manage_pcsd_service {
+        service { 'pcsd':
+          ensure  => running,
+          enable  => true,
+          require => Package['pcs'],
+        }
       }
     }
   }


### PR DESCRIPTION
Hi, I've notice that the corosync module install the pcs package on RedHat systems but didn't manage the status of the service associated.

So I've add the resource service with requirement to the package pcs. Because we need it to be up and running after installing it.

Hope it will be helpful.
Thanks.
Julien Georges <julien.georges@atos.net>