### PR TITLE
Adding rule property to pcs location

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,22 @@ cs_location { 'nginx_service_location':
   score     => 'INFINITY'
 }
 ```
+
+To manage rule on a location.
+Example to force the location to not run on a container (VM).
+
+```puppet
+cs_location { 'nginx_service_location':
+  primitive => 'nginx_service',
+  rule      => { 'score'      => '-INFINITY',
+                 'expression' => { 'attribute' => '#kind',
+                                   'operation' => 'eq',
+                                   'value'     => 'container'
+                 }
+               }
+}
+```
+
 Configuring colocations
 -----------------------
 

--- a/lib/puppet/provider/cs_location/pcs.rb
+++ b/lib/puppet/provider/cs_location/pcs.rb
@@ -20,6 +20,35 @@ Puppet::Type.type(:cs_location).provide(:pcs, parent: PuppetX::Voxpupuli::Corosy
 
   mk_resource_methods
 
+  # given an XML element containing some <expression>s, return a hash. Return an
+  # empty hash if `e` is nil.
+  def self.rules_to_hash(e)
+    return {} if e.nil?
+
+    hash = {}
+    e.each_element do |i|
+      hash[i.attributes['name']] = i.attributes['value']
+    end
+
+    hash
+  end
+
+  # given an XML element (a <rsc_location> from cibadmin), produce a hash
+  # suitable for creating a new provider instance.
+  def self.element_to_hash(e)
+    hash = {
+      name:      e.attributes['id'],
+      ensure:    :present,
+      primitive: e.attributes['rsc'],
+      node_name: e.attributes['node'],
+      score:     e.attributes['score'],
+      rule:      rules_to_hash(e.elements['rule']),
+      provider:  name
+    }
+
+    hash
+  end
+
   def self.instances
     block_until_ready
 
@@ -41,6 +70,7 @@ Puppet::Type.type(:cs_location).provide(:pcs, parent: PuppetX::Voxpupuli::Corosy
           node_name:          items['node'],
           score:              items['score'],
           resource_discovery: items['resource-discovery'],
+          rule:               items['rule'],
           provider:           name
         }
         instances << new(location_instance)
@@ -58,7 +88,8 @@ Puppet::Type.type(:cs_location).provide(:pcs, parent: PuppetX::Voxpupuli::Corosy
       primitive:          @resource[:primitive],
       node_name:          @resource[:node_name],
       score:              @resource[:score],
-      resource_discovery: @resource[:resource_discovery]
+      resource_discovery: @resource[:resource_discovery],
+      rule:               @resource[:rule]
     }
   end
 
@@ -82,6 +113,20 @@ Puppet::Type.type(:cs_location).provide(:pcs, parent: PuppetX::Voxpupuli::Corosy
       cmd = ['pcs', 'constraint', 'location', 'add', @property_hash[:name], @property_hash[:primitive], @property_hash[:node_name], @property_hash[:score]]
       cmd << "resource-discovery=#{@property_hash[:resource_discovery]}" unless @property_hash[:resource_discovery].nil?
       PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib(cmd, @resource[:cib])
+
+      unless @property_hash[:rule].nil?
+        score_param = [] # default value: score=INFINITY
+        rule_params = []
+        @property_hash[:rule].each_pair do |k, v|
+          if k == 'expression' # expression
+            rule_params = [v['attribute'], v['operation'], v['value']]
+          elsif k == 'score' || k == 'score-attribute' # score or score-attribute
+            score_param = "#{k}=#{v}"
+          end
+        end
+        cmd_rule = [command(:pcs), 'constraint', 'location', @property_hash[:primitive], 'rule', score_param, rule_params]
+        PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib(cmd_rule, @resource[:cib])
+      end
     end
   end
 end

--- a/lib/puppet/type/cs_location.rb
+++ b/lib/puppet/type/cs_location.rb
@@ -51,6 +51,12 @@ Puppet::Type.newtype(:cs_location) do
     defaultto 'INFINITY'
   end
 
+  newproperty(:rule) do
+    desc "The rule of this location.
+
+          The rule_type should be expression or date_expression."
+  end
+
   autorequire(:cs_shadow) do
     autos = []
     autos << @parameters[:cib].value if @parameters[:cib]
@@ -59,5 +65,11 @@ Puppet::Type.newtype(:cs_location) do
 
   autorequire(:service) do
     %w(corosync pacemaker)
+  end
+
+  validate do
+    if [self[:node_name], self[:rule]].compact.length > 1
+      raise Puppet::Error, 'Location constraints dictate that node_name and rule cannot co-exist for this type.'
+    end
   end
 end

--- a/spec/acceptance/cs_location_spec.rb
+++ b/spec/acceptance/cs_location_spec.rb
@@ -101,4 +101,26 @@ NWyN0RsTXFaqowV1/HSyvfD7LoF/CrmN5gOAM3Ierv/Ti9uqGVhdGBd/kw=='
       expect(r.stdout).not_to match(%r{resource-discovery="exclusive"}) if fact('osfamily') != 'RedHat'
     end
   end
+
+  it 'creates a location with a rule' do
+    pp = <<-EOS
+      cs_location { 'duncan_vip_not_in_container':
+        primitive => 'duncan_vip',
+        rule      => {
+          score      => '-INFINITY',
+          expression => {
+            attribute => '#kind',
+            operation => 'eq',
+            value     => 'container',
+          },
+        }
+      }
+    EOS
+    apply_manifest(pp, debug: true, catch_failures: true)
+    apply_manifest(pp, debug: true, catch_changes: true)
+    shell('cibadmin --query | grep duncan_vip_not_in_container-rule') do |r|
+      expect(r.stdout).to match(%r{<rule id="duncan_vip_not_in_container-rule" score="-INFINITY">})
+      expect(r.stdout).to match(%r{<expression attribute="#kind" id="duncan_vip_not_in_container-rule-expr" operation="eq" value="container"/>})
+    end
+  end
 end


### PR DESCRIPTION
# Overview
On our infrastructure we need to add some rule to manage location constraints with pcs. But this feature wasn't supported by the puppetlabs-corosync module.

Here is my Pull Request to add this functionnality.

# How to do it manually

To add a rule, you need to execute the following commands :
`/usr/sbin/pcs constraint location add location-sv-dummy sv-dummy1 node_name.domain INFINITY`
`/usr/sbin/pcs constraint location sv-dummy1 rule score=-INFINITY #kind eq container`

That gives us this xml output from `pcs cluster cib` command:
```xml
      <rsc_location id="location-sv-dummy" node="node_name.domain" rsc="sv-dummy1" score="INFINITY"/>
      <rsc_location id="location-sv-dummy1" rsc="sv-dummy1">
        <rule id="location-sv-dummy1-rule" score="-INFINITY">
          <expression attribute="#kind" id="location-sv-dummy1-rule-expr" operation="eq" value="container"/>
        </rule>
      </rsc_location>
```

And you should obtain the following output from `pcs constraint location show` command:
```
  Resource: sv-dummy1
    Enabled on: node_name.domain (score:INFINITY)
    Constraint: location-sv-dummy1
      Rule: score=-INFINITY
        Expression: #kind eq container
```

This rule means that you deny (-INFINITY) to launch your resource on a container (like VM).

# How to manage it with Puppet

Example of how you can set your rule with the following Puppet code.

```puppet
    cs_location { 'location-sv-dummy':
      primitive => 'sv-dummy1',
      rule      => { 'score'      => '-INFINITY',
                     'expression' => { 'attribute' => '#kind',
                                       'operation' => 'eq',
                                       'value'     => 'container'
                     }
                   }
    }
```

By default,  the rule => score is set to score=INFINITY (see pcs man page). You can also use score-attributes instead of score.
The expression determines the operation to execute for this rule.

When you applied it, it works fine:
```puppet
    Debug: Cs_location[location-sv-dummy](provider=pcs): {}
    Notice: /Stage[main]/Main/Cs_location[location-sv-dummy]/ensure: created
    Debug: Executing '/usr/sbin/pcs constraint location add location-sv-dummy sv-dummy1 node_name.domain INFINITY'
    Debug: Executing '/usr/sbin/pcs constraint location sv-dummy1 rule score=-INFINITY #kind eq container'
    Debug: /Stage[main]/Main/Cs_location[location-sv-dummy]: The container Class[Main] will propagate my refresh event
    Debug: Class[Main]: The container Stage[main] will propagate my refresh event
```

# Issues

There is still a problem with my code and I didn't find how to solve it yet. This problem appears when you apply for the second time your configuration.

Here is the Puppet output for this issue :
```puppet
    Debug: Cs_location[location-sv-dummy](provider=pcs): {:name=>"location-sv-dummy", :ensure=>:present, :primitive=>"sv-dummy1", :node_name=>"node_name.domain", :score=>"INFINITY", :provider=>:pcs, :rule=>{}}
    Notice: /Stage[main]/Main/Cs_location[location-sv-dummy]/rule: rule changed {} to '{"score"=>"-INFINITY", "expression"=>{"attribute"=>"#kind", "operation"=>"eq", "value"=>"container"}}'
    Debug: Executing '/usr/sbin/pcs constraint location add location-sv-dummy sv-dummy1 node_name.domain INFINITY'
    Debug: Executing '/usr/sbin/pcs constraint location sv-dummy1 rule score=-INFINITY #kind eq container'
    Error: /Stage[main]/Main/Cs_location[location-sv-dummy]: Could not evaluate: Execution of '/usr/sbin/pcs constraint location sv-dummy1 rule score=-INFINITY #kind eq container' returned 1: 
```

I suppose that the data obtains from the xml output are not correctly set on my rule variable but I didn't know how to solve it, so don't hesitate to send me your ideas if you can solve it ^^

Thanks for your help.
Julien Georges <julien.georges@atos.net>