### PR TITLE
Preserve resource order in cs_group crm provider

### DIFF
--- a/lib/puppet/provider/cs_group/crm.rb
+++ b/lib/puppet/provider/cs_group/crm.rb
@@ -78,7 +78,7 @@ Puppet::Type.type(:cs_group).provide(:crm, :parent => Puppet::Provider::Crmsh) d
   # resource already exists so we just update the current value in the property
   # hash and doing this marks it to be flushed.
   def primitives=(should)
-    @property_hash[:primitives] = should.sort
+    @property_hash[:primitives] = should
   end
 
   # Flush is triggered on anything that has been detected as being


### PR DESCRIPTION
User provided resource order may be significant. For example, if one has an
ocf::heartbeat:LVM resource named „vg01” and ocf::heartbeat:Filesystem resource
named „varlibpostgresql” on an lv in the vg01 volume group, cluster will try to
start varlibpostgresql before vg01.