### PR TITLE
Implemented quorum.expected_votes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,10 @@
 #   is set to true.
 #   Defaults to undef,
 #
+# [*quorum_expected_votes*]
+#   Number of expected votes.
+#   Defaults to false
+#
 # [*token*]
 #   Time (in ms) to wait for a token
 #
@@ -112,6 +116,7 @@ class corosync(
   $ttl                                 = $::corosync::params::ttl,
   $packages                            = $::corosync::params::packages,
   $set_votequorum                      = $::corosync::params::set_votequorum,
+  $quorum_expected_votes               = $::corosync::params::quorum_expected_votes,
   $quorum_members                      = ['localhost'],
   $token                               = $::corosync::params::token,
   $token_retransmits_before_loss_const = $::corosync::params::token_retransmits_before_lost_const,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class corosync::params {
   $packages                            = ['corosync', 'pacemaker']
   $token                               = 3000
   $token_retransmits_before_lost_const = 10
+  $quorum_expected_votes               = false
 
   case $::osfamily {
     'RedHat': {

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -56,6 +56,9 @@ aisexec {
 <% if @set_votequorum -%>
 quorum {
   provider: corosync_votequorum
+<% if @quorum_expected_votes -%>
+  expected_votes: <%= @quorum_expected_votes %>
+<% end -%>
 }
 
 nodelist {

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -55,6 +55,9 @@ aisexec {
 <% if @set_votequorum -%>
 quorum {
   provider: corosync_votequorum
+<% if @quorum_expected_votes -%>
+  expected_votes: <%= @quorum_expected_votes %>
+<% end -%>
 }
 
 nodelist {


### PR DESCRIPTION
When you are bootstrapping a cluster of 3 nodes and configure those, pacemaker will have no quorum if not at least 2 nodes are up. To override that function (useful for bootstrapping, because one might only bootstrap the other after the first), one needs to configure expected_votes in quorum { }.