### PR TITLE
Missing autorequire for cs_group on cs_commit type.

### DIFF
--- a/lib/puppet/type/cs_commit.rb
+++ b/lib/puppet/type/cs_commit.rb
@@ -40,6 +40,9 @@ Puppet::Type.newtype(:cs_commit) do
     resources_with_cib :cs_location
   end
 
+  autorequire(:cs_group) do
+    resources_with_cib :cs_group
+  end
 
   autorequire(:cs_order) do
     resources_with_cib :cs_order


### PR DESCRIPTION
Hi,

I just fixed a missing autorequire for cs_group on the cs_commit type.

Thanks.