### PR TITLE
Add parameters for corosync.conf file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,11 @@
 #   This specifies the name of cluster and it's used for automatic
 #   generating of multicast address.
 #
+# [*join*]
+#   This timeout specifies in milliseconds how long to wait for join messages
+#   in the membership protocol.
+#   Default to 50
+#
 # [*consensus*]
 #   This timeout specifies in milliseconds how long to wait for consensus to be
 #   achieved before starting a new round of membership configuration.
@@ -169,6 +174,7 @@ class corosync(
   $compatibility                       = $::corosync::params::compatibility,
   $manage_pacemaker_service            = $::corosync::params::manage_pacemaker_service,
   $cluster_name                        = $::corosync::params::cluster_name,
+  $join                                = $::corosync::params::join,
   $consensus                           = $::corosync::params::consensus,
 ) inherits ::corosync::params {
 
@@ -321,6 +327,7 @@ class corosync(
   # - $enable_secauth_real
   # - $threads
   # - $token
+  # - $join
   # - $consensus
   file { '/etc/corosync/corosync.conf':
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,12 @@
 #   consensus value.
 #   Defaults to false,
 #
+# [*max_messages*]
+#   This constant specifies the maximum number of messages that may be sent by
+#   one processor on receipt of the token. The max_messages parameter is limited
+#   to 256000 / netmtu to prevent overflow of the kernel transmit buffers.
+#   Defaults to 17
+#
 # === Deprecated Parameters
 #
 # [*packages*]
@@ -176,6 +182,7 @@ class corosync(
   $cluster_name                        = $::corosync::params::cluster_name,
   $join                                = $::corosync::params::join,
   $consensus                           = $::corosync::params::consensus,
+  $max_messages                        = $::corosync::params::max_messages,
 ) inherits ::corosync::params {
 
   if $set_votequorum and !$quorum_members {
@@ -329,6 +336,7 @@ class corosync(
   # - $token
   # - $join
   # - $consensus
+  # - $max_messages
   file { '/etc/corosync/corosync.conf':
     ensure  => file,
     mode    => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,14 @@
 #   This specifies the name of cluster and it's used for automatic
 #   generating of multicast address.
 #
+# [*consensus*]
+#   This timeout specifies in milliseconds how long to wait for consensus to be
+#   achieved before starting a new round of membership configuration.
+#   The minimum value for consensus must be 1.2 * token. This value will be
+#   automatically calculated at 1.2 * token if the user doesn't specify a
+#   consensus value.
+#   Defaults to false,
+#
 # === Deprecated Parameters
 #
 # [*packages*]
@@ -161,6 +169,7 @@ class corosync(
   $compatibility                       = $::corosync::params::compatibility,
   $manage_pacemaker_service            = $::corosync::params::manage_pacemaker_service,
   $cluster_name                        = $::corosync::params::cluster_name,
+  $consensus                           = $::corosync::params::consensus,
 ) inherits ::corosync::params {
 
   if $set_votequorum and !$quorum_members {
@@ -312,6 +321,7 @@ class corosync(
   # - $enable_secauth_real
   # - $threads
   # - $token
+  # - $consensus
   file { '/etc/corosync/corosync.conf':
     ensure  => file,
     mode    => '0644',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class corosync::params {
   $cluster_name                        = undef
   $join                                = 50
   $consensus                           = false
+  $max_messages                        = 17
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class corosync::params {
   $token_retransmits_before_lost_const = 10
   $votequorum_expected_votes           = false
   $cluster_name                        = undef
+  $join                                = 50
   $consensus                           = false
 
   case $::osfamily {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class corosync::params {
   $token_retransmits_before_lost_const = 10
   $votequorum_expected_votes           = false
   $cluster_name                        = undef
+  $consensus                           = false
 
   case $::osfamily {
     'RedHat': {

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -9,7 +9,7 @@ totem {
 <% end -%>
   token:                               <%= @token %>
   token_retransmits_before_loss_const: <%= @token_retransmits_before_loss_const %>
-  join:                                60
+  join:                                <%= @join %>
 <% if @consensus -%>
   consensus:                           <%= @consensus %>
 <% end -%>

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -14,7 +14,7 @@ totem {
   consensus:                           <%= @consensus %>
 <% end -%>
   vsftype:                             none
-  max_messages:                        20
+  max_messages:                        <%= @max_messages %>
   clear_node_high_bit:                 yes
   rrp_mode:                            <%= @rrp_mode %>
   secauth:                             <%= @enable_secauth_real %>

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -10,7 +10,9 @@ totem {
   token:                               <%= @token %>
   token_retransmits_before_loss_const: <%= @token_retransmits_before_loss_const %>
   join:                                60
-  consensus:                           3600
+<% if @consensus -%>
+  consensus:                           <%= @consensus %>
+<% end -%>
   vsftype:                             none
   max_messages:                        20
   clear_node_high_bit:                 yes

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -9,7 +9,7 @@ totem {
 <% end -%>
   token:                               <%= @token %>
   token_retransmits_before_loss_const: <%= @token_retransmits_before_loss_const %>
-  join:                                60
+  join:                                <%= @join %>
 <% if @consensus -%>
   consensus:                           <%= @consensus %>
 <% end -%>

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -14,7 +14,7 @@ totem {
   consensus:                           <%= @consensus %>
 <% end -%>
   vsftype:                             none
-  max_messages:                        20
+  max_messages:                        <%= @max_messages %>
   clear_node_high_bit:                 yes
   rrp_mode:                            <%= @rrp_mode %>
   secauth:                             <%= @enable_secauth_real %>

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -10,7 +10,9 @@ totem {
   token:                               <%= @token %>
   token_retransmits_before_loss_const: <%= @token_retransmits_before_loss_const %>
   join:                                60
-  consensus:                           3600
+<% if @consensus -%>
+  consensus:                           <%= @consensus %>
+<% end -%>
   vsftype:                             none
   max_messages:                        20
   clear_node_high_bit:                 yes


### PR DESCRIPTION
Hi,

I've just add few missing parameters that could be mandatory to configure some of your corosync.conf files.

**consensus**
According to the man page, if the consensus value is not specified corosync will automatically calculate it to 1.2x the token value. We can manage the token value but not the consensus value so for me it's irrelevant.

**join**
Adding the parameter join. According to the man page, by default it's set to 50 milliseconds.

**max_messages**
Adding the parameter max_messages. According to the man page, by default it's set to 17.