### PR TITLE
Fix detached node epoch mismatch

### DIFF
--- a/lib/puppet/provider/cs_property/crm.rb
+++ b/lib/puppet/provider/cs_property/crm.rb
@@ -81,7 +81,37 @@ Puppet::Type.type(:cs_property).provide(:crm, :parent => Puppet::Provider::Crmsh
       # clear this on properties, in case it's set from a previous
       # run of a different corosync type
       ENV['CIB_shadow'] = nil
-      crm('configure', 'property', '$id="cib-bootstrap-options"', "#{@property_hash[:name]}=#{@property_hash[:value]}")
+      begin
+        crm('configure', 'property', '$id="cib-bootstrap-options"', "#{@property_hash[:name]}=#{@property_hash[:value]}")
+      rescue
+        xml = <<-EOF
+        <diff>
+          <diff-removed>
+            <cib>
+              <configuration>
+                <crm_config>
+                  <cluster_property_set id="cib-bootstrap-options">
+                    <nvpair value=#{@property_hash[:value].inspect} id=#{@property_hash[:name].inspect}/>
+                  </cluster_property_set>
+                </crm_config>
+              </configuration>
+            </cib>
+          </diff-removed>
+          <diff-added>
+            <cib>
+              <configuration>
+                <crm_config>
+                  <cluster_property_set id="cib-bootstrap-options">
+                    <nvpair value="stop" id="cib-bootstrap-options-no-quorum-policy"/>
+                  </cluster_property_set>
+                </crm_config>
+              </configuration>
+            </cib>
+          </diff-added>
+        </diff>
+        EOF
+        cibadmin("--patch", "--sync-call", "--xml-text", xml)
+      end
     end
   end
 end


### PR DESCRIPTION
Pacemaker maintains an internal database, which is used for
configuration storage. Each update of this database increases a counter,
called "epoch", which should have the same value cluster-wide.

If an update operation comes to a previously detached node, a conflict
will occur. Pacemaker does not allow updating this database on a node,
which epoch value is lower than the epoch value of a cluster leader.

However, it is safe to force the update during the bootstrap phase. It
can be implemented by directly manipulating the values by using
"cibadmin" utility (and providing the delta XML) instead of "crm".