### PR TITLE
update README.md, fix example with operations with the same names

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,16 @@ cs_primitive { 'apache_service':
 }
 ```
 
-Note: Operations with the same names should be declared as an Array. Example:
+Note: Operations with the same names have to be distinguished by role defined behind the colon. Example:
 ```puppet
 cs_primitive { 'pgsql_service':
   primitive_class => 'ocf',
   primitive_type  => 'pgsql',
   provided_by     => 'heartbeat',
   operations      => {
-    'monitor' => [
-      { 'interval' => '10s', 'timeout' => '30s' },
-      { 'interval' => '5s', 'timeout' => '30s', 'role' => 'Master' },
-    ],
-    'start'   => { 'interval' => '0', 'timeout' => '30s', 'on-fail' => 'restart' }
+    'monitor'        => { 'interval' => '10s', 'timeout' => '30s' },
+    'monitor:Master' => { 'interval' => '5s', 'timeout' => '30s' },
+    'start'          => { 'interval' => '0', 'timeout' => '30s', 'on-fail' => 'restart' }
   },
 }
 ```


### PR DESCRIPTION
I tried the example with array but it failed with the error that 'each_pair' method is not defined for array. I discussed the right syntax with Julien @roidelapluie which works well.