### PR TITLE
Compare versions using Puppet::Util::Package.versioncmp

### DIFF
--- a/lib/puppet/provider/crmsh.rb
+++ b/lib/puppet/provider/crmsh.rb
@@ -14,7 +14,7 @@ class Puppet::Provider::Crmsh < Puppet::Provider
   def self.ready?
     return true if @@crmready
     cmd =  [ command(:crm_attribute), '--type', 'crm_config', '--query', '--name', 'dc-version' ]
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
     else
       raw = Puppet::Util::Execution.execute(cmd, :failonfail => false, :combine => true)

--- a/lib/puppet/provider/cs_clone/crm.rb
+++ b/lib/puppet/provider/cs_clone/crm.rb
@@ -29,7 +29,7 @@ Puppet::Type.type(:cs_clone).provide(:crm, :parent => Puppet::Provider::Crmsh) d
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
     else
       raw = Puppet::Util::Execution.execute(cmd)

--- a/lib/puppet/provider/cs_colocation/crm.rb
+++ b/lib/puppet/provider/cs_colocation/crm.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:cs_colocation).provide(:crm, :parent => Puppet::Provider::Crm
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
     else
       raw = Puppet::Util::Execution.execute(cmd)

--- a/lib/puppet/provider/cs_group/crm.rb
+++ b/lib/puppet/provider/cs_group/crm.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:cs_group).provide(:crm, :parent => Puppet::Provider::Crmsh) d
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
     else
       raw = Puppet::Util::Execution.execute(cmd)

--- a/lib/puppet/provider/cs_location/crm.rb
+++ b/lib/puppet/provider/cs_location/crm.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:cs_location).provide(:crm, :parent => Puppet::Provider::Crmsh
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
        raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
     else
        raw = Puppet::Util::Execution.execute(cmd)

--- a/lib/puppet/provider/cs_order/crm.rb
+++ b/lib/puppet/provider/cs_order/crm.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:cs_order).provide(:crm, :parent => Puppet::Provider::Crmsh) d
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
     else
       raw = Puppet::Util::Execution.execute(cmd)

--- a/lib/puppet/provider/cs_property/crm.rb
+++ b/lib/puppet/provider/cs_property/crm.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:cs_property).provide(:crm, :parent => Puppet::Provider::Crmsh
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
     else
       raw = Puppet::Util::Execution.execute(cmd)

--- a/lib/puppet/provider/cs_rsc_defaults/crm.rb
+++ b/lib/puppet/provider/cs_rsc_defaults/crm.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:cs_rsc_defaults).provide(:crm, :parent => Puppet::Provider::C
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
     else
       raw = Puppet::Util::Execution.execute(cmd)

--- a/lib/puppet/provider/pacemaker.rb
+++ b/lib/puppet/provider/pacemaker.rb
@@ -7,7 +7,7 @@ class Puppet::Provider::Pacemaker < Puppet::Provider
   commands :pcs => 'pcs'
 
   def self.run_pcs_command(pcs_cmd, failonfail = true)
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       raw, status = Puppet::Util::SUIDManager.run_and_capture(pcs_cmd)
     else
       raw = Puppet::Util::Execution.execute(pcs_cmd, {:failonfail => failonfail})

--- a/spec/unit/puppet/provider/corosync_spec.rb
+++ b/spec/unit/puppet/provider/corosync_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Provider::Crmsh do
     end
 
     it 'returns false when crm_attribute exits unsuccessfully' do
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['crm_attribute', '--type', 'crm_config', '--query', '--name', 'dc-version']).returns(['', 1])
       else
         Puppet::Util::Execution.expects(:execute).with(['crm_attribute', '--type', 'crm_config', '--query', '--name', 'dc-version'],{:combine => true, :failonfail => false}).returns(
@@ -32,7 +32,7 @@ describe Puppet::Provider::Crmsh do
     end
 
     it 'returns true when crm_attribute exits successfully' do
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['crm_attribute', '--type', 'crm_config', '--query', '--name', 'dc-version']).returns(['', 0])
       else
         Puppet::Util::Execution.expects(:execute).with(['crm_attribute', '--type', 'crm_config', '--query', '--name', 'dc-version'],{:combine => true, :failonfail => false}).returns(

--- a/spec/unit/puppet/provider/cs_clone_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_crm_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:cs_clone).provider(:crm) do
       EOS
 
       described_class.expects(:block_until_ready).returns(nil)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns([test_cib, 0])
       else
         Puppet::Util::Execution.expects(:execute).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns(

--- a/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:cs_clone).provider(:pcs) do
       EOS
 
       described_class.expects(:block_until_ready).returns(nil)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['pcs', 'cluster', 'cib']).at_least_once.returns([test_cib, 0])
       else
         Puppet::Util::Execution.expects(:execute).with(['pcs', 'cluster', 'cib'], {:failonfail => true}).at_least_once.returns(
@@ -56,7 +56,7 @@ describe Puppet::Type.type(:cs_clone).provider(:pcs) do
 
   context 'when flushing' do
     def expect_update(pattern)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with { |*args|
           cmdline=args[0].join(" ")
           expect(cmdline).to match(pattern)

--- a/spec/unit/puppet/provider/cs_colocation_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_colocation_crm_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Type.type(:cs_colocation).provider(:crm) do
   end
 
   let :instances do
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
       Puppet::Util::SUIDManager.expects(:run_and_capture).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns([test_cib, 0])
     else
       Puppet::Util::Execution.expects(:execute).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns(

--- a/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:cs_primitive).provider(:crm) do
       EOS
 
       described_class.expects(:block_until_ready).returns(nil)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns([test_cib, 0])
       else
         Puppet::Util::Execution.expects(:execute).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns(

--- a/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::Type.type(:cs_primitive).provider(:pcs) do
       EOS
 
       described_class.expects(:block_until_ready).returns(nil)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['pcs', 'cluster', 'cib']).at_least_once.returns([test_cib, 0])
       else
         Puppet::Util::Execution.expects(:execute).with(['pcs', 'cluster', 'cib'], {:failonfail => true}).at_least_once.returns(
@@ -120,7 +120,7 @@ describe Puppet::Type.type(:cs_primitive).provider(:pcs) do
       EOS
 
       described_class.expects(:block_until_ready).returns(nil)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['pcs', 'cluster', 'cib']).at_least_once.returns([test_cib, 0])
       else
         Puppet::Util::Execution.expects(:execute).with(['pcs', 'cluster', 'cib'], {:failonfail => true}).at_least_once.returns(
@@ -131,7 +131,7 @@ describe Puppet::Type.type(:cs_primitive).provider(:pcs) do
     end
 
     def expect_update(pattern)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with { |*args|
           cmdline=args[0].join(" ")
           expect(cmdline).to match(pattern)

--- a/spec/unit/puppet/provider/cs_property_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_property_crm_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:cs_property).provider(:crm) do
       EOS
 
       described_class.expects(:block_until_ready).returns(nil)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns([test_cib, 0])
       else
         Puppet::Util::Execution.expects(:execute).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns(

--- a/spec/unit/puppet/provider/cs_rsc_defaults_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_rsc_defaults_crm_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:cs_rsc_defaults).provider(:crm) do
       EOS
 
       described_class.expects(:block_until_ready).returns(nil)
-      if Puppet::PUPPETVERSION.to_f < 3.4
+      if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
         Puppet::Util::SUIDManager.expects(:run_and_capture).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns([test_cib, 0])
       else
         Puppet::Util::Execution.expects(:execute).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns(


### PR DESCRIPTION
Thit commit switches the way we compare versions to Puppet versioncmp
function.

The previous approach (which uses to_f) would not see 3.10 as more
recent that 3.2 because 3.10 < 3.2 if you threat them as floats.