### PR TITLE
Add persistent node IDs as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ class { 'corosync':
 }
 ```
 
+Configure votequorum
+--------------------
+
+*To enable Corosync 2 votequorum and define a nodelist
+of nodes named n1, n2, n3 with auto generated node IDs*
+
+```puppet
+class { 'corosync':
+  set_votequorum => true,
+  quorum_members => [ 'n1', 'n2', 'n3' ],
+}
+```
+
+*To do the same but with custom node IDs instead*
+```puppet
+class { 'corosync':
+  set_votequorum     => true,
+  quorum_members     => [ 'n1', 'n2', 'n3' ],
+  quorum_members_ids => [ 10, 11, 12 ],
+}
+```
+Note: custom IDs may be required when adding or removing
+nodes to a cluster on a fly. Then each node shall have an
+unique and persistent ID.
+
 Configuring primitives
 ------------------------
 
@@ -108,7 +133,7 @@ cs_primitive { 'pgsql_service':
 Configuring locations
 -----------------------
 
-Locations determine on which nodes primitive resources run. 
+Locations determine on which nodes primitive resources run.
 
 ```puppet
 cs_location { 'nginx_service_location':
@@ -172,7 +197,7 @@ cs_property { 'stonith-enabled' :
 }
 ```
 
-Change quorum policy 
+Change quorum policy
 ```
 cs_property { 'no-quorum-policy' :
   value   => 'ignore',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,7 +106,12 @@
 # [*quorum_members*]
 #   Array of quorum member hostname. This is required if set_votequorum
 #   is set to true.
-#   Defaults to undef,
+#   Defaults to ['localhost']
+#
+# [*quorum_members_ids*]                                                                                                                                                                  #   Array of quorum member IDs. Persistent IDs are required for the dynamic
+#   config of a corosync cluster and when_set_votequorum is set to true.
+#   Should be used only with the quorum_members parameter.
+#   Defaults to undef
 #
 # [*token*]
 #   Time (in ms) to wait for a token
@@ -191,6 +196,7 @@ class corosync(
   $set_votequorum                      = $::corosync::params::set_votequorum,
   $votequorum_expected_votes           = $::corosync::params::votequorum_expected_votes,
   $quorum_members                      = ['localhost'],
+  $quorum_members_ids                  = undef,
   $token                               = $::corosync::params::token,
   $token_retransmits_before_loss_const = $::corosync::params::token_retransmits_before_lost_const,
   $compatibility                       = $::corosync::params::compatibility,
@@ -203,6 +209,10 @@ class corosync(
 
   if $set_votequorum and !$quorum_members {
     fail('set_votequorum is true, but no quorum_members have been passed.')
+  }
+
+  if $quorum_members_ids and !$quorum_members {
+    fail('quorum_members_ids may not be used without the quorum_members.')
   }
 
   if $packages {
@@ -330,7 +340,7 @@ class corosync(
     } else {
       $_package_pcs = $package_pcs
     }
-  
+
     if $version_pcs == undef {
       $_version_pcs = present
     } else {

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -23,10 +23,25 @@ describe 'corosync' do
           /nodelist/
         )
         should contain_file('/etc/corosync/corosync.conf').with_content(
-          /ring0_addr\: node1\.test\.org/
+          /ring0_addr\: node1\.test\.org\n\s*nodeid: 1/
         )
         should contain_file('/etc/corosync/corosync.conf').with_content(
-          /ring0_addr\: node2\.test\.org/
+          /ring0_addr\: node2\.test\.org\n\s*nodeid: 2/
+        )
+      end
+
+      it 'supports persistent node IDs' do
+        params.merge!( {
+          :quorum_members_ids => [3, 11] }
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /nodelist/
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /ring0_addr\: node1\.test\.org\n\s*nodeid: 3/
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /ring0_addr\: node2\.test\.org\n\s*nodeid: 11/
         )
       end
     end

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -92,7 +92,11 @@ nodelist {
 <% [@quorum_members].flatten.each_index do |i| -%>
   node {
     ring0_addr: <%= [@quorum_members].flatten[i] %>
+<% if @quorum_members_ids.nil? -%>
     nodeid: <%= i+1 %>
+<% else -%>
+    nodeid: <%= [@quorum_members_ids].flatten[i] %>
+<% end -%>
   }
 <% end -%>
 }


### PR DESCRIPTION
Use the quorum_members_ids parameter when node IDs
shall not be autogenerated.

Closes-bug: #issues/193

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>