### PR TITLE
crm_shadow --commit/--delete need --force to execute

### DIFF
--- a/lib/puppet/provider/cs_commit/pcs.rb
+++ b/lib/puppet/provider/cs_commit/pcs.rb
@@ -10,6 +10,6 @@ Puppet::Type.type(:cs_commit).provide(:pcs, :parent => Puppet::Provider::Pacemak
   end
 
   def sync(cib)
-    crm_shadow('--commit', cib)
+    crm_shadow('--force', '--commit', cib)
   end
 end

--- a/lib/puppet/provider/cs_shadow/pcs.rb
+++ b/lib/puppet/provider/cs_shadow/pcs.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:cs_shadow).provide(:pcs, :parent => Puppet::Provider::Pacemak
 
   def sync(cib)
     begin
-      crm_shadow('--delete', cib)
+      crm_shadow('--force', '--delete', cib)
     rescue => e
       # If the CIB doesn't exist, we don't care.
     end


### PR DESCRIPTION
The --force flag is mandatory to effectively commit/delete a shadow CIB.

Without the --force we obtain the following error message: 
Error: /Stage[main]/Common_ha/Cs_commit[GHOST]/cib: change from absent to GHOST failed: Execution of '/usr/sbin/crm_shadow --commit GHOST' returned 64: The supplied command is considered dangerous.  To prevent accidental destruction of the cluster, the --force flag is required in order to proceed.