### PR TITLE
Fix function call syntax in cs_colocation PCS provider

### DIFF
--- a/lib/puppet/provider/cs_colocation/pcs.rb
+++ b/lib/puppet/provider/cs_colocation/pcs.rb
@@ -110,7 +110,7 @@ Puppet::Type.type(:cs_colocation).provide(:pcs, :parent => Puppet::Provider::Pac
       cmd << "add"
       rsc = @property_hash[:primitives].pop
       if rsc.include? ':'
-        items = rsc.split[':']
+        items = rsc.split(':')
         if items[1] == 'Master'
           cmd << 'master'
         elsif items[1] == 'Slave'


### PR DESCRIPTION
A trivial little patch, but it took some time to find the error.

It seems to exist in the develop branch as well.