### PR TITLE
Enable pacemaker by default on Centos7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,11 @@ class corosync::params {
     'RedHat': {
       $set_votequorum = true
       $compatibility = 'whitetank'
-      $manage_pacemaker_service = false
+      if versioncmp($::operatingsystemrelease, '7') >= 0 {
+        $manage_pacemaker_service = true
+      } else {
+        $manage_pacemaker_service = false
+      }
     }
 
     'Debian': {

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -192,6 +192,30 @@ describe 'corosync' do
         :ipaddress      => '127.0.0.1' }
     end
 
-    it_configures 'corosync'
+    context 'major version is 6' do
+      before do
+        facts.merge!(:operatingsystemrelease => '6.12')
+      end
+
+      it_configures 'corosync'
+
+      it 'does not manage the pacemaker service' do
+        should_not contain_service('pacemaker')
+      end
+    end
+
+    context 'major version is 7' do
+      before do
+        facts.merge!(:operatingsystemrelease => '7.3')
+      end
+
+      it_configures 'corosync'
+
+      it 'does manage the pacemaker service' do
+        should contain_service('pacemaker').with(
+          :ensure => 'running'
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Without this commit, the corosync module does not work under el7 because
it loops on:

Debug: Puppet::Type::Cs_primitive::ProviderPcs: Corosync
not ready, retrying:
Debug: Executing: '/sbin/pcs property show dc-version'