### PR TITLE
Document set_votequorum defaults correctly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,7 +101,9 @@
 #
 # [*set_votequorum*]
 #   Set to true if corosync_votequorum should be used as quorum provider.
-#   Defaults to false.
+#   Defaults to true on RedHat based operating systems.
+#   Defaults to true on Ubuntu version 14.04 or greater.
+#   Defaults to false on all other operating systems.
 #
 # [*quorum_members*]
 #   Array of quorum member hostname. This is required if set_votequorum


### PR DESCRIPTION
This logic here:
https://github.com/voxpupuli/puppet-corosync/blob/master/manifests/params.pp#L28
is currently not documented correctly.

Updating a rather old version of this module on a RedHat based system surprisingly added a quorum block to our configuration although it was documented to not do this.
