### PR TITLE
Managing to_logfile

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,10 @@
 #   True/false parameter specifying whether puppet should return an error log
 #   message if a node is in standby. Useful for monitoring node state.
 #
+# [*to_logfile*]
+#   True/false parameter specifying whether Corosync should produce debug
+#   output in 'logfile'.
+#
 # [*debug*]
 #   True/false parameter specifying whether Corosync should produce debug
 #   output in its logs.
@@ -126,6 +130,7 @@ class corosync(
   $unicast_addresses                   = $::corosync::params::unicast_addresses,
   $force_online                        = $::corosync::params::force_online,
   $check_standby                       = $::corosync::params::check_standby,
+  $to_logfile                          = $::corosync::params::to_logfile
   $debug                               = $::corosync::params::debug,
   $rrp_mode                            = $::corosync::params::rrp_mode,
   $ttl                                 = $::corosync::params::ttl,
@@ -211,6 +216,7 @@ class corosync(
   validate_bool($force_online)
   validate_bool($check_standby)
   validate_bool($debug)
+  validate_bool($to_logfile)
 
   if $unicast_addresses == 'UNSET' {
     $corosync_conf = "${module_name}/corosync.conf.erb"
@@ -269,6 +275,7 @@ class corosync(
   # Template uses:
   # - $unicast_addresses
   # - $multicast_address
+  # - $to_logfile
   # - $debug
   # - $bind_address
   # - $port

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class corosync::params {
   $force_online                        = false
   $check_standby                       = false
   $debug                               = false
+  $to_logfile                          = false
   $rrp_mode                            = 'none'
   $ttl                                 = false
   $token                               = 3000

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -32,7 +32,8 @@ totem {
 logging {
   fileline:        off
   to_stderr:       yes
-  to_logfile:      no
+  to_logfile:      <%= scope.lookupvar('to_logfile') ? 'on' : 'off' %>
+  logfile:         /var/log/corosync.log
   to_syslog:       yes
   syslog_facility: daemon
   debug:           <%= scope.lookupvar('debug') ? 'on' : 'off' %>
@@ -65,5 +66,5 @@ nodelist {
     nodeid: <%= i+1 %>
   }
 <% end -%>
-}
+
 <% end -%>

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -31,7 +31,8 @@ totem {
 logging {
   fileline:        off
   to_stderr:       yes
-  to_logfile:      no
+  to_logfile:      <%= scope.lookupvar('to_logfile') ? 'on' : 'off' %>
+  logfile:         /var/log/corosync.log
   to_syslog:       yes
   syslog_facility: daemon
   debug:           <%= scope.lookupvar('debug') ? 'on' : 'off' %>


### PR DESCRIPTION
- Manage "to_logfile" directive
- Set a default logile (/var/log/corosync.log) on Debian, the packager thought it was a good idea to write in /var/log/cluster/corosync.log, where /var/log/cluster doesn't exist.