### PR TITLE
Release 1.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-##Next
-###
+##2016-04-11 - Release 1.0.0-beta
+###Summary
 - Ubuntu 14.04 support (#178)
 - pcs provider: improved support for cs\_shadow, cs\_commit(#197 #196 #209)
 - cs\_property now takes an optional `replace` parameter that do not update

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-corosync",
-  "version": "0.8.0",
+  "version": "1.0.0-beta",
   "author": "puppet-community",
   "summary": "This module is a set of manifests and types/providers for quickly setting up highly available clusters using Corosync",
   "license": "Apache-2.0",


### PR DESCRIPTION
I would like that we release a beta version once #209 will be merged.

Then I will finish the todo list in #206 and at that time we will be able to release 1.0.0-rc1.

After bugfixes, we could then release rc2 which I hope will end in 1.0.0.

The major version bump is due to the changes in cs_colocation in #209 (order of the primitives has changed).