### PR TITLE
Remove ENV['CIB_shadow'] where not needed

### DIFF
--- a/lib/puppet/provider/cs_colocation/pcs.rb
+++ b/lib/puppet/provider/cs_colocation/pcs.rb
@@ -148,9 +148,6 @@ Puppet::Type.type(:cs_colocation).provide(:pcs, :parent => Puppet::Provider::Pac
   # as stdin for the pcs command.
   def flush
     unless @property_hash.empty?
-
-      ENV['CIB_shadow'] = @property_hash[:cib]
-
       if @property_hash[:new] == false
         debug('Removing colocation')
         cmd = [command(:pcs), 'constraint', 'remove', @resource[:name]]

--- a/lib/puppet/provider/cs_group/pcs.rb
+++ b/lib/puppet/provider/cs_group/pcs.rb
@@ -84,9 +84,6 @@ Puppet::Type.type(:cs_group).provide(:pcs, :parent => Puppet::Provider::Pacemake
   # as stdin for the pcs command.
   def flush
     unless @property_hash.empty?
-
-      ENV['CIB_shadow'] = @resource[:cib]
-
       if @property_hash[:new] == false
         debug('Removing group')
         Puppet::Provider::Pacemaker.run_command_in_cib([command(:pcs), 'resource', 'ungroup', @property_hash[:name]], @resource[:cib])


### PR DESCRIPTION
Since #209 ENV['CIB_shadow'] is not needed anymore for cs_colocation and
cs_group.