### PR TITLE
Unpromote master resources in shadow CIB

### DIFF
--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -126,7 +126,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
       @property_hash[:promotable] = should
     when :false
       @property_hash[:promotable] = should
-      pcs('resource', 'delete', "ms_#{@resource[:name]}")
+      Puppet::Provider::Pacemaker.run_command_in_cib([command(:pcs), 'resource', 'delete', "ms_#{@resource[:name]}"], @resource[:cib])
     end
   end
 


### PR DESCRIPTION
The unpromoting af a resource did not happen en the shadow CIB, but in
the CIB directly (even when a cib => parameter was there).