### PR TITLE
Fix persistent node IDs for all conf cases

### DIFF
--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -61,10 +61,23 @@ describe 'corosync' do
           /nodelist/
         )
         should contain_file('/etc/corosync/corosync.conf').with_content(
-          /ring0_addr\: node1\.test\.org/
+          /ring0_addr\: node1\.test\.org\n\s*nodeid: 1/
         )
         should contain_file('/etc/corosync/corosync.conf').with_content(
-          /ring0_addr\: node2\.test\.org/
+          /ring0_addr\: node2\.test\.org\n\s*nodeid: 2/
+        )
+      end
+
+      it 'supports persistent node IDs' do
+        params[:quorum_members_ids] = [3, 11]
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /nodelist/
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /ring0_addr\: node1\.test\.org\n\s*nodeid: 3/
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /ring0_addr\: node2\.test\.org\n\s*nodeid: 11/
         )
       end
     end

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -91,7 +91,11 @@ nodelist {
 <% [@quorum_members].flatten.each_index do |i| -%>
   node {
     ring0_addr: <%= [@quorum_members].flatten[i] %>
+<% if @quorum_members_ids.nil? -%>
     nodeid: <%= i+1 %>
+<% else -%>
+    nodeid: <%= [@quorum_members_ids].flatten[i] %>
+<% end -%>
   }
 <% end -%>
 }


### PR DESCRIPTION
Use the quorum_members_ids parameter when node IDs
shall not be autogenerated for the corosync.conf.udpu.erb
as well.

Related-bug: #issues/193

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>