### PR TITLE
Fix to work with Ruby 2.3 (in Ubuntu 16.04).

### DIFF
--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -35,11 +35,11 @@ Puppet::Type.type(:cs_primitive).provide(:crm, parent: Puppet::Provider::Crmsh) 
     unless operations.nil?
       operations.each_element do |o|
         valids = o.attributes.reject do |k, _v| k == 'id' end
-        name = valids['name']
+        name = valids['name'].to_s
         operation = {}
         operation[name] = {}
         valids.each do |k, v|
-          operation[name][k] = v if k != 'name'
+          operation[name][k] = v.to_s if k != 'name'
         end
         unless o.elements['instance_attributes'].nil?
           o.elements['instance_attributes'].each_element do |i|

--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -46,11 +46,11 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, parent: Puppet::Provider::Pacemak
     unless operations.nil?
       operations.each_element do |o|
         valids = o.attributes.reject do |k, _v| k == 'id' end
-        name = valids['name']
+        name = valids['name'].to_s
         operation = {}
         operation[name] = {}
         valids.each do |k, v|
-          operation[name][k] = v if k != 'name'
+          operation[name][k] = v.to_s if k != 'name'
         end
         unless o.elements['instance_attributes'].nil?
           o.elements['instance_attributes'].each_element do |i|

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -245,11 +245,14 @@ describe 'corosync' do
     context 'when configuring defaults for logging' do
       it 'should configure stderr, syslog priority, func names' do
         should contain_file('/etc/corosync/corosync.conf').with_content(
-          /to_stderr:       yes/)
+          /to_stderr:       yes/
+        )
         should contain_file('/etc/corosync/corosync.conf').with_content(
-          /syslog_priority: info/)
+          /syslog_priority: info/
+        )
         should_not contain_file('/etc/corosync/corosync.conf').with_content(
-          /function_name:   on/)
+          /function_name:   on/
+        )
       end
     end
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,7 +33,6 @@ RSpec.configure do |c|
   end
 end
 
-# rubocop:disable Style/PredicateName
 def is_future_parser_enabled?
   # rubocop:disable Style/GuardClause
   if default[:type] == 'aio'
@@ -44,7 +43,6 @@ def is_future_parser_enabled?
   end
   false
 end
-# rubocop:enable Style/PredicateName
 
 # rubocop:disable Style/AccessorMethodName
 def get_puppet_version

--- a/spec/unit/puppet/provider/cs_clone_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_crm_spec.rb
@@ -72,7 +72,8 @@ describe Puppet::Type.type(:cs_clone).provider(:crm) do
         name:      'p_keystone-clone',
         provider:  :crm,
         primitive: 'p_keystone',
-        ensure:    :present)
+        ensure:    :present
+      )
     end
 
     let :instance do

--- a/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
@@ -62,7 +62,8 @@ describe Puppet::Type.type(:cs_clone).provider(:pcs) do
         name:      'p_keystone',
         provider:  :pcs,
         primitive: 'p_keystone',
-        ensure:    :present)
+        ensure:    :present
+      )
     end
 
     let :instance do

--- a/spec/unit/puppet/provider/cs_colocation_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_colocation_crm_spec.rb
@@ -90,7 +90,8 @@ describe Puppet::Type.type(:cs_colocation).provider(:crm) do
           name:       'first_with_second',
           provider:   :crm,
           primitives: %w(first second),
-          ensure:     :present)
+          ensure:     :present
+        )
       end
 
       let :instance do
@@ -135,7 +136,8 @@ describe Puppet::Type.type(:cs_colocation).provider(:crm) do
           name:       'first_with_second_with_third',
           provider:   :crm,
           primitives: %w(first second third),
-          ensure:     :present)
+          ensure:     :present
+        )
       end
 
       let :instance do

--- a/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
@@ -120,7 +120,8 @@ describe Puppet::Type.type(:cs_primitive).provider(:crm) do
         provider: :crm,
         primitive_class: 'ocf',
         provided_by: 'heartbeat',
-        primitive_type: 'IPaddr2')
+        primitive_type: 'IPaddr2'
+      )
     end
 
     let :instance do

--- a/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
@@ -147,7 +147,8 @@ h           <primitive class="ocf" id="example_vip_with_op" provider="heartbeat"
         primitive_class: 'ocf',
         provided_by: 'heartbeat',
         operations: { 'monitor' => { 'interval' => '60s' } },
-        primitive_type: 'IPaddr2')
+        primitive_type: 'IPaddr2'
+      )
     end
 
     let :instance do


### PR DESCRIPTION
The elements are of type REXML::Attribute. Using them directly results in values like `name='monitor'`, rather than just `monitor`. Using to_s gives the desired value, and works fine in Ruby 1.9 (in Ubuntu 14.04) and Ruby 2.3 (in Ubuntu 16.04).

The visible outcome without this change is that operations are reapplied on every Puppet run because the cs_primitive type doesn't think they're equal.

Note: I haven't checked if there are other cases that are similar elsewhere in the module. I haven't tripped over any yet though. Also, Ruby is not a primary language for me, so it's possible I've overlooked something. Hopefully this is a good starting point though.