### PR TITLE
Ensure autorequires is empty if there is no cib parameters

### DIFF
--- a/lib/puppet/type/cs_clone.rb
+++ b/lib/puppet/type/cs_clone.rb
@@ -68,7 +68,9 @@ Puppet::Type.newtype(:cs_clone) do
   end
 
   autorequire(:cs_shadow) do
-    [@parameters[:cib]]
+    autos = []
+    autos << @parameters[:cib].value if @parameters[:cib]
+    autos
   end
 
   autorequire(:service) do

--- a/lib/puppet/type/cs_colocation.rb
+++ b/lib/puppet/type/cs_colocation.rb
@@ -76,7 +76,9 @@ Puppet::Type.newtype(:cs_colocation) do
   end
 
   autorequire(:cs_shadow) do
-    [@parameters[:cib]]
+    autos = []
+    autos << @parameters[:cib].value if @parameters[:cib]
+    autos
   end
 
   autorequire(:service) do

--- a/lib/puppet/type/cs_commit.rb
+++ b/lib/puppet/type/cs_commit.rb
@@ -24,7 +24,9 @@ Puppet::Type.newtype(:cs_commit) do
   end
 
   autorequire(:cs_shadow) do
-    [@parameters[:cib]]
+    autos = []
+    autos << @parameters[:cib].value if @parameters[:cib]
+    autos
   end
 
   if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '4.0') < 0

--- a/lib/puppet/type/cs_group.rb
+++ b/lib/puppet/type/cs_group.rb
@@ -43,7 +43,9 @@ Puppet::Type.newtype(:cs_group) do
   end
 
   autorequire(:cs_shadow) do
-    [@parameters[:cib]]
+    autos = []
+    autos << @parameters[:cib].value if @parameters[:cib]
+    autos
   end
 
   autorequire(:service) do

--- a/lib/puppet/type/cs_location.rb
+++ b/lib/puppet/type/cs_location.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:cs_location) do
   end
 
   autorequire(:cs_shadow) do
-    [@parameters[:cib]]
+    autos = []
+    autos << @parameters[:cib].value if @parameters[:cib]
+    autos
   end
 
   autorequire(:service) do

--- a/lib/puppet/type/cs_order.rb
+++ b/lib/puppet/type/cs_order.rb
@@ -102,7 +102,9 @@ Puppet::Type.newtype(:cs_order) do
   end
 
   autorequire(:cs_shadow) do
-    [@parameters[:cib]]
+    autos = []
+    autos << @parameters[:cib].value if @parameters[:cib]
+    autos
   end
 
   def unmunge_cs_resourcename(name)

--- a/lib/puppet/type/cs_primitive.rb
+++ b/lib/puppet/type/cs_primitive.rb
@@ -235,7 +235,9 @@ Puppet::Type.newtype(:cs_primitive) do
   end
 
   autorequire(:cs_shadow) do
-    [@parameters[:cib]]
+    autos = []
+    autos << @parameters[:cib].value if @parameters[:cib]
+    autos
   end
 
   autorequire(:service) do

--- a/lib/puppet/type/cs_property.rb
+++ b/lib/puppet/type/cs_property.rb
@@ -59,7 +59,9 @@ Puppet::Type.newtype(:cs_property) do
   end
 
   autorequire(:cs_shadow) do
-    [@parameters[:cib]]
+    autos = []
+    autos << @parameters[:cib].value if @parameters[:cib]
+    autos
   end
 
   autorequire(:service) do


### PR DESCRIPTION
Puppet 4.5.0 Compatibility

Since puppetlabs/puppet@eff7ac6fd73adb11ba98fb993c29fac69b473297 it is
no longer possible to have [nil] in autorequires.

This commit fixes it for cs_shadow dependencies.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>