### PR TITLE
Add Puppet Compatibility to metadata.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   Cs\_primitive[unmanaged\_metadata] parameter (#275)
 - Support Debian 8. Requires jessie-backports apt repository (not included in
   this module) (#282)
+- Set Puppet requirement version to >= 3.0.0 < 5.0.0 (#286)
 
 ### Backward incompatible changes
 - Cs\_primitive[manage\_target\_role] parameter (introduced in 1.1.0, deprecated
@@ -12,6 +13,11 @@
   replace `manage_target_role => false` by `unmanaged_metadata => ['targes-role']`
 - The class parameter corosync::packages has been removed (was deprecated in
   0.8.0) (#282)
+
+### Deprecation notes
+
+We will remove support for Puppet <= 3.6.0 in two major releases of this module
+(4.0.0).
 
 ## 2016-06-16 - Release 1.2.1
 ### Summary

--- a/lib/puppet_x/voxpupuli/corosync/provider/cib_helper.rb
+++ b/lib/puppet_x/voxpupuli/corosync/provider/cib_helper.rb
@@ -18,6 +18,7 @@ class PuppetX::Voxpupuli::Corosync::Provider::CibHelper < Puppet::Provider
     debug("Executing #{cmd} in the CIB") if cib.nil?
     debug("Executing #{cmd} in the shadow CIB \"#{cib}\"") unless cib.nil?
     if Puppet::Util::Package.versioncmp(Puppet::PUPPETVERSION, '3.4') == -1
+      Puppet.deprecation_warning 'voxpupuli-corosync: Support for Puppet < 3.6 will be dropped in the release 4.0.0 of the voxpupuli-corosync module'
       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd, nil, nil, custom_environment)
     else
       raw = Puppet::Util::Execution.execute(cmd, { failonfail: failonfail }.merge(custom_environment))

--- a/metadata.json
+++ b/metadata.json
@@ -35,6 +35,10 @@
   ],
   "dependencies": [
     {
+        "name": "puppet",
+        "version_requirement": ">= 3.0.0 < 5.0.0"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": "4.x"
     }


### PR DESCRIPTION


And prepare deprecation of Puppet 3.5 and beyond

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>