### PR TITLE
allow corosync configuration with cluster_name only

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -307,9 +307,9 @@ class corosync(
     $corosync_conf = "${module_name}/corosync.conf.udpu.erb"
   }
 
-  # $multicast_address is NOT required if $unicast_address is provided
-  if $multicast_address == 'UNSET' and $unicast_addresses == 'UNSET' {
-      fail('You must provide a value for multicast_address')
+  #  You have to specify at least one of the following parameters $multicast_address, $unicast_address or $cluster_name
+  if $multicast_address == 'UNSET' and $unicast_addresses == 'UNSET' and !$cluster_name {
+      fail('You must provide a value for multicast_address, unicast_address or cluster_name.')
   }
 
   case $enable_secauth {
@@ -360,6 +360,7 @@ class corosync(
   # Template uses:
   # - $unicast_addresses
   # - $multicast_address
+  # - $cluster_name
   # - $log_file
   # - $debug
   # - $bind_address

--- a/spec/acceptance/corosync_class_spec.rb
+++ b/spec/acceptance/corosync_class_spec.rb
@@ -1,0 +1,54 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper_acceptance'
+
+# These tests are designed to ensure that the module, when ran with
+# cluster_name option only, sets up everything correctly and allows
+# us to connect to Postgres.
+describe 'corosync' do
+  cert = '-----BEGIN CERTIFICATE-----
+MIIDVzCCAj+gAwIBAgIJAJNCo5ZPmKegMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNV
+BAYTAlhYMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQg
+Q29tcGFueSBMdGQwHhcNMTUwMjI2MjI1MjU5WhcNMTUwMzI4MjI1MjU5WjBCMQsw
+CQYDVQQGEwJYWDEVMBMGA1UEBwwMRGVmYXVsdCBDaXR5MRwwGgYDVQQKDBNEZWZh
+dWx0IENvbXBhbnkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+uCPPbDgErGUVs1pKqv59OatjCEU4P9QcmhDYFR7RBN8m08mIqd+RTuiHUKj6C9Rk
+vWQ5bYrGQo/+4E0ziAUuUzzITlpIYLVltca6eBhKUqO3Cd0NMRVc2k4nx5948nwv
+9FVOIfOOY6BN2ALglfBfLnhObbzJjs6OSZ7bUCpXVPV01t/61Jj3jQ3+R8b7AaoR
+mw7j0uWaFimKt/uag1qqKGw3ilieMhHlG0Da5x9WLi+5VIM0t1rcpR58LLXVvXZB
+CrQBucm2xhZsz7R76Ai+NL8zhhyzCZidZ2NtJ3E1wzppcSDAfNrru+rcFSlZ4YG+
+lMCqZ1aqKWVXmb8+Vg7IkQIDAQABo1AwTjAdBgNVHQ4EFgQULxI68KhZwEF5Q9al
+xZmFDR+Beu4wHwYDVR0jBBgwFoAULxI68KhZwEF5Q9alxZmFDR+Beu4wDAYDVR0T
+BAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAsa0YKPixD6VmDo3pal2qqichHbdT
+hUONk2ozzRoaibVocqKx2T6Ho23wb/lDlRUu4K4DMO663uumzI9lNoOewa0MuW1D
+J52cejAMVsP3ROOdxBv0HZIVVJ8NLBHNLFOHJEDtvzogLVplzmo59vPAdmQo6eIV
+japvs+0tdy9iwHj3z1ZME2Ntm/5TzG537e7Hb2zogatM9aBTUAWlZ1tpoaXuTH52
+J76GtqoIOh+CTeY/BMwBotdQdgeR0zvjE9FuLWkhTmRtVFhbVIzJbFlFuYq5d3LH
+NWyN0RsTXFaqowV1/HSyvfD7LoF/CrmN5gOAM3Ierv/Ti9uqGVhdGBd/kw=='
+  File.open('/tmp/ca.pem', 'w') { |f| f.write(cert) }
+  it 'with only cluster_name' do
+    pp = <<-EOS
+      file { '/tmp/ca.pem':
+        ensure  => file,
+        content => '#{cert}'
+      } ->
+      class { 'corosync':
+        cluster_name      => 'hacell',
+        authkey           => '/tmp/ca.pem',
+        bind_address      => '127.0.0.1',
+        set_votequorum    => true,
+        quorum_members    => ['127.0.0.1'],
+      }
+    EOS
+
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe service('corosync') do
+    it { is_expected.to be_running }
+  end
+
+  describe service('pacemaker') do
+    it { is_expected.to be_running }
+  end
+end

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -165,6 +165,21 @@ describe 'corosync' do
       end
     end
 
+    context 'when multicast_address, unicast_addresses and cluster_name are not set' do
+      before :each do
+        params.merge!(
+          multicast_address: 'UNSET'
+        )
+      end
+
+      it 'raises error' do
+        should raise_error(
+          Puppet::Error,
+          %r{You must provide a value for multicast_address, unicast_address or cluster_name\.}
+        )
+      end
+    end
+
     context 'when log_file is set' do
       before :each do
         params.merge!(

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -23,7 +23,8 @@ totem {
   interface {
     ringnumber:  <%= i %>
     bindnetaddr: <%= [@bind_address].flatten[i] %>
-<% if [@multicast_address].flatten[i] == 'broadcast' -%>
+<% if @multicast_address == 'UNSET' -%>
+<% elsif [@multicast_address].flatten[i] == 'broadcast' -%>
     broadcast:   yes
 <% else -%>
     mcastaddr:   <%= [@multicast_address].flatten[i] %>


### PR DESCRIPTION
This commit allows to use _cluster_name_ parameter only without the declaration of _multicast_address_ nor _unicast_addresses_.

It is valid configuration to set only _cluster_name_ and it also can be configured with multicast address or unicast together. Multicast address has higher priority than cluster name. (https://github.com/corosync/corosync/blob/master/man/corosync.conf.5#L120).

The puppet code was ready for that so I only extended the condition which checks if one of these 3 parameters (_multicast_address, _unicast_addresses_ or _cluster_name_) is set. I also added acceptance for that.
