### PR TITLE
Fix disabling of authkey

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -341,6 +341,7 @@ class corosync(
           notify  => Service['corosync'],
           require => Package['corosync'],
         }
+        File['/etc/corosync/authkey'] -> File['/etc/corosync/corosync.conf']
       }
       'string': {
         file { '/etc/corosync/authkey':
@@ -352,6 +353,7 @@ class corosync(
           notify  => Service['corosync'],
           require => Package['corosync'],
         }
+        File['/etc/corosync/authkey'] -> File['/etc/corosync/corosync.conf']
       }
       default: {}
     }
@@ -388,10 +390,7 @@ class corosync(
       group        => 'root',
       content      => template($corosync_conf),
       validate_cmd => '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t',
-      require      => [
-        File['/etc/corosync/authkey'],
-        Package['corosync'],
-      ],
+      require      => Package['corosync'],
     }
   } else {
     file { '/etc/corosync/corosync.conf':

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -7,7 +7,7 @@ describe 'corosync' do
   end
 
   shared_examples_for 'corosync' do
-    it { is_expected.to compile }
+    it { is_expected.to compile.with_all_deps }
 
     context 'when set_quorum is true and quorum_members are set' do
       before do
@@ -122,6 +122,22 @@ describe 'corosync' do
           )
           should contain_file('/etc/corosync/corosync.conf').with_content(
             %r{ring0_addr\: node2\.test\.org\n\s*nodeid: 11}
+          )
+        end
+      end
+
+      context 'witout secauth' do
+        before do
+          params.merge!(
+            enable_secauth: false
+          )
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it 'configures secauth correctly' do
+          should contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{secauth:\s+off}
           )
         end
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

55421df42cd832dfdf073f455d21ce4782e6c92c introduced a dependency
between /etc/corosync/corosync.conf and /etc/corosync/authkey.

However, the second one does not exist when enable_secauth is set to
false. This is now taken into consideration to manage the dependency.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>