### PR TITLE
Fix two_nodes behaviour with expected_votes = 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   Those parameters can now be specified as class parameters. (#345)
 - Removed legacy configuration sections: amf, aisexec, logging.logger\_subsys
   (#345)
+- Fix two\_nodes behaviour with expected\_votes = 2 introduced in 3.0.0 (#246)
 
 ### Deprecation notes
 

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -56,12 +56,26 @@ describe 'corosync' do
         before do
           params.merge!(
             quorum_members: ['node1.test.org', 'node2.test.org', 'node3.test.org'],
-            votequorum_expected_votes: 2
+            votequorum_expected_votes: 3
           )
         end
 
         it 'does not configure two_nodes option' do
           should_not contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{two_node: 1}
+          )
+        end
+      end
+
+      context 'when quorum_members is not set and votequorum_expected_votes is set' do
+        before do
+          params.merge!(
+            votequorum_expected_votes: 2
+          )
+        end
+
+        it 'configures two_node' do
+          should contain_file('/etc/corosync/corosync.conf').with_content(
             %r{two_node: 1}
           )
         end

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -100,8 +100,11 @@ quorum {
   provider: corosync_votequorum
 <% if @votequorum_expected_votes -%>
   expected_votes: <%= @votequorum_expected_votes %>
+<%-# .to_i is needed for Puppet 3 -%>
+<% if @votequorum_expected_votes.to_i == 2 -%>
+  two_node: 1
 <% end -%>
-<% if [@quorum_members].flatten.count == 2 -%>
+<% elsif [@quorum_members].flatten.count == 2 -%>
   two_node: 1
 <% end -%>
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

commit 9a54a5c6b7974eba7456bdcd3bd6c654ed15350c introduced a wrong
behaviour: when expected_votes is 2, then two_nodes should be set to 1,
even  if you do not specify quorum_members

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>