### PR TITLE
Support timestamp and logfile config options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,10 +53,18 @@
 # [*check_standby*]
 #   True/false parameter specifying whether puppet should return an error log
 #   message if a node is in standby. Useful for monitoring node state.
+
+# [*log_timestamp*]
+#   Boolean parameter specifying whether a timestamp should be placed on all
+#   log messages. Default: false
 #
 # [*log_file*]
 #   Boolean parameter specifying whether Corosync should produce debug
 #   output in a logfile. Default: true.
+#
+# [*log_file_name*]
+#   Absolute path to the logfile Corosync should use when `$log_file` (see
+#   above) is true. Default: not set
 #
 # [*debug*]
 #   True/false parameter specifying whether Corosync should produce debug
@@ -231,7 +239,9 @@ class corosync(
   $unicast_addresses                   = $::corosync::params::unicast_addresses,
   $force_online                        = $::corosync::params::force_online,
   $check_standby                       = $::corosync::params::check_standby,
+  $log_timestamp                       = $::corosync::params::log_timestamp,
   $log_file                            = $::corosync::params::log_file,
+  $log_file_name                       = $::corosync::params::log_file_name,
   $debug                               = $::corosync::params::debug,
   $log_stderr                          = $::corosync::params::log_stderr,
   $syslog_priority                     = $::corosync::params::syslog_priority,
@@ -311,6 +321,10 @@ class corosync(
   validate_bool($force_online)
   validate_bool($check_standby)
   validate_bool($log_file)
+  if getvar('log_file_name') and $log_file == true {
+    validate_absolute_path($log_file_name)
+  }
+  validate_bool($log_timestamp)
   validate_bool($debug)
   validate_bool($log_stderr)
   validate_re($syslog_priority, '^(debug|info|notice|warning|err|emerg)$')
@@ -373,7 +387,9 @@ class corosync(
   # - $unicast_addresses
   # - $multicast_address
   # - $cluster_name
+  # - $log_timestamp
   # - $log_file
+  # - $log_file_name
   # - $debug
   # - $bind_address
   # - $port

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,9 @@ class corosync::params {
   $unicast_addresses                   = 'UNSET'
   $force_online                        = false
   $check_standby                       = false
+  $log_timestamp                       = false
   $log_file                            = true
+  $log_file_name                       = undef
   $debug                               = false
   $log_stderr                          = true
   $syslog_priority                     = 'info'

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -313,10 +313,87 @@ describe 'corosync' do
       end
     end
 
+    context 'when log_timestamp is not set' do
+      it 'does not set timestamp' do
+        is_expected.to contain_file('/etc/corosync/corosync.conf').without_content(
+          %r{timestamp}
+        )
+      end
+    end
+
+    context 'when log_timestamp is false' do
+      before do
+        params.merge!(
+          log_timestamp: false
+        )
+      end
+
+      it 'does not set timestamp' do
+        is_expected.to contain_file('/etc/corosync/corosync.conf').without_content(
+          %r{timestamp}
+        )
+      end
+    end
+
+    context 'when log_timestamp is set' do
+      before do
+        params.merge!(
+          log_timestamp: true
+        )
+      end
+
+      it 'does set timestamp' do
+        is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+          %r{timestamp.*on}
+        )
+      end
+    end
+
     context 'when log_file is not set' do
       it 'does set to_logfile' do
         is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
           %r{to_logfile.*yes}
+        )
+      end
+      it 'does not set logfile' do
+        is_expected.to contain_file('/etc/corosync/corosync.conf').without_content(
+          %r{^\s*logfile}
+        )
+      end
+    end
+
+    context 'when log_file and log_file_name are set' do
+      before do
+        params.merge!(
+          log_file: true,
+          log_file_name: '/var/log/corosync/corosync.log'
+        )
+      end
+
+      it 'does set to_logfile' do
+        is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+          %r{to_logfile.*yes}
+        )
+      end
+      it 'does set logfile' do
+        is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+          %r{logfile.*\/var\/log\/corosync/corosync\.log}
+        )
+      end
+    end
+
+    context 'when log_file_name is not an absolute path' do
+      before do
+        params.merge!(
+          log_file: true,
+          log_file_name: 'corosync.log'
+        )
+      end
+
+      it 'raises error' do
+        is_expected.to raise_error(
+          Puppet::Error,
+          %r{is not an absolute path}
         )
       end
     end
@@ -331,6 +408,11 @@ describe 'corosync' do
       it 'does not set to_logfile' do
         is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
           %r{to_logfile.*no}
+        )
+      end
+      it 'does not set logfile' do
+        is_expected.to contain_file('/etc/corosync/corosync.conf').without_content(
+          %r{^\s*logfile}
         )
       end
     end

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -80,6 +80,9 @@ totem {
 
 logging {
   fileline:        off
+<% if @log_timestamp -%>
+  timestamp:       on
+<% end -%>
 <% if @log_stderr -%>
   to_stderr:       yes
 <% else -%>
@@ -87,6 +90,9 @@ logging {
 <% end -%>
 <% if @log_file -%>
   to_logfile:      yes
+<% if @log_file_name -%>
+  logfile:         <%= @log_file_name %>
+<% end -%>
 <% else -%>
   to_logfile:      no
 <% end -%>


### PR DESCRIPTION
Add new class parameters "log_timestamp" and "log_file_name".

log_timestamp is false by default; the "timestamp" option is only
enabled in corosync.conf if log_timestamp => true.

log_file_name is not set by default; the "logfile" option is only set in
corosync.conf if log_file => true and log_file_name is an absolute path.
If log_file_name is not an absolute path catalog compilation will fail.

Includes spec tests and class parameter docs. This change is fully
backwards compatible and does not change the contents of corosync.conf
if the new parameters are left at their defaults.