### PR TITLE
Bump min version_requirement for Puppet + dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ We do maintain a [roadmap regarding next releases of this module](ROADMAP.md).
 
 ### Operating System support matrix
 
-| OS          | release | Puppet 3.8    | Puppet 4.X (PC1) |
+| OS          | release | Puppet 3.8.7    | Puppet 4.X (PC1) |
 |-------------|---------|---------------|------------------|
 | CentOS/RHEL | 5       | Not supported | Not supported    |
 | CentOS/RHEL | 6       | Not supported | Not supported    |

--- a/metadata.json
+++ b/metadata.json
@@ -37,13 +37,13 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.8.0 < 5.0.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": "4.x"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump stdlib to the minimum version that should work under Puppet 4,
based on the metadata