### PR TITLE
cs_location should require cs_group

### DIFF
--- a/lib/puppet/type/cs_location.rb
+++ b/lib/puppet/type/cs_location.rb
@@ -95,7 +95,7 @@ Puppet::Type.newtype(:cs_location) do
     %w(corosync pacemaker)
   end
 
-  [:cs_primitive, :cs_clone].each do |type|
+  [:cs_primitive, :cs_clone, :cs_group].each do |type|
     autorequire(type) do
       autos = []
       autos << unmunge_cs_primitive(should(:primitive)) if should(:primitive)

--- a/spec/unit/puppet/type/cs_location_spec.rb
+++ b/spec/unit/puppet/type/cs_location_spec.rb
@@ -129,6 +129,30 @@ describe Puppet::Type.type(:cs_location) do
     end
   end
 
+  describe 'establishing autorequires between locations and groups' do
+    let(:apache_group) { create_cs_group_resource('apache_group', ['apache_vip', 'apache_service']) }
+    let(:apache_location) { create_cs_location_resource('apache_group') }
+
+    before do
+      create_catalog(apache_group, apache_location)
+    end
+
+    context 'between a location and its group' do
+      let(:autorequire_relationship) { apache_location.autorequire[0] }
+
+      it 'has exactly one autorequire' do
+        expect(apache_location.autorequire.count).to eq(1)
+      end
+
+      it 'has apache group as source of autorequire' do
+        expect(autorequire_relationship.source).to eq apache_group
+      end
+      it 'has apache location as target of autorequire' do
+        expect(autorequire_relationship.target).to eq apache_location
+      end
+    end
+  end
+
   describe 'establishing autorequires between location and services' do
     let(:pacemaker_service) { create_service_resource('pacemaker') }
     let(:corosync_service) { create_service_resource('corosync') }


### PR DESCRIPTION
cs_location works with cs_group (at last with crm). It should the
autorequire it.

Fix #396

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
