### PR TITLE
Require Package['corosync'] breaks puppetrun if $package_corosync/pacemaker is set to false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -406,7 +406,6 @@ class corosync(
       group        => 'root',
       content      => template("${module_name}/corosync.conf.erb"),
       validate_cmd => '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t',
-      require      => Package['corosync'],
     }
   } else {
     file { '/etc/corosync/corosync.conf':
@@ -415,7 +414,6 @@ class corosync(
       owner   => 'root',
       group   => 'root',
       content => template("${module_name}/corosync.conf.erb"),
-      require => Package['corosync'],
     }
   }
 
@@ -426,7 +424,6 @@ class corosync(
     group   => 'root',
     recurse => true,
     purge   => true,
-    require => Package['corosync'],
   }
 
   case $::osfamily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -355,7 +355,6 @@ class corosync(
           owner   => 'root',
           group   => 'root',
           notify  => Service['corosync'],
-          require => Package['corosync'],
         }
         File['/etc/corosync/authkey'] -> File['/etc/corosync/corosync.conf']
       }
@@ -367,7 +366,6 @@ class corosync(
           owner   => 'root',
           group   => 'root',
           notify  => Service['corosync'],
-          require => Package['corosync'],
         }
         File['/etc/corosync/authkey'] -> File['/etc/corosync/corosync.conf']
       }


### PR DESCRIPTION
Require Package['corosync']/Package['pacemaker'] breaks puppetrun if $package_corosync/pacemaker is set to false. Not able to use other repo or packages or just to use puppet to create a basic config when $package_corosync/pacemaker is set to false.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
