### PR TITLE
[WIP] Migrate manifests to puppet4

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ class { 'corosync':
   authkey        => '/var/lib/puppet/ssl/certs/ca.pem',
   bind_address   => $::ipaddress,
   cluster_name   => 'mycluster',
-  enable_secauth => true,
+  enable_secauth => 'on',
 }
 ```
 
@@ -382,7 +382,7 @@ bind_address as arrays:
 
 ```puppet
 class { 'corosync':
-  enable_secauth    => true,
+  enable_secauth    => 'on',
   authkey           => '/var/lib/puppet/ssl/certs/ca.pem',
   bind_address      => ['10.0.0.1', '10.0.1.1'],
   unicast_addresses => [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@
 #
 # [*enable_secauth*]
 #   Controls corosync's ability to authenticate and encrypt multicast messages.
+#   Default: 'on'
 #
 # [*authkey_source*]
 #   Allows to use either a file or a string as a authkey.
@@ -22,6 +23,7 @@
 #   How many threads you are going to let corosync use to encode and decode
 #   multicast messages.  If you turn off secauth then corosync will ignore
 #   threads.
+#   Default: undef
 #
 # [*bind_address*]
 #   The ip address we are going to bind the corosync daemon too.
@@ -47,124 +49,141 @@
 #   each subarray matches a host IP addresses.
 #
 # [*force_online*]
-#   True/false parameter specifying whether to force nodes that have been put
+#   Boolean parameter specifying whether to force nodes that have been put
 #   in standby back online.
+#   Default: false
 #
 # [*check_standby*]
-#   True/false parameter specifying whether puppet should return an error log
+#   Boolean parameter specifying whether puppet should return an error log
 #   message if a node is in standby. Useful for monitoring node state.
-
+#   Default: false
+#
 # [*log_timestamp*]
 #   Boolean parameter specifying whether a timestamp should be placed on all
-#   log messages. Default: false
+#   log messages.
+#   Default: false
 #
 # [*log_file*]
 #   Boolean parameter specifying whether Corosync should produce debug
-#   output in a logfile. Default: true.
+#   output in a logfile.
+#   Default: true
 #
 # [*log_file_name*]
 #   Absolute path to the logfile Corosync should use when `$log_file` (see
-#   above) is true. Default: not set
+#   above) is true.
+#   Default: undef
 #
 # [*debug*]
-#   True/false parameter specifying whether Corosync should produce debug
+#   Boolean parameter specifying whether Corosync should produce debug
 #   output in its logs.
+#   Default: false
 #
 # [*log_stderr*]
-#   True/false parameter specifying whether Corosync should log errors to
-#   stderr. Defaults to True.
+#   Boolean parameter specifying whether Corosync should log errors to
+#   stderr.
+#   Default: true
 #
 # [*syslog_priority*]
 #   String parameter specifying the minimal log level for Corosync syslog
 #   messages. Allowed values: debug|info|notice|warning|err|emerg.
-#   Defaults to 'info'.
+#   Default: 'info'.
 #
 # [*log_function_name*]
-#   True/false parameter specifying whether Corosync should log called funcions
-#   names to. Defaults to False.
+#   Boolean parameter specifying whether Corosync should log called function
+#   names to.
+#   Default: false
 #
 # [*rrp_mode*]
 #   Mode of redundant ring. May be none, active, or passive.
+#   Default: undef
 #
 # [*netmtu*]
 #   This specifies the network maximum transmit unit.
+#   Default: undef
 #
 # [*ttl*]
 #   Time To Live.
+#   Default: undef
 #
 # [*vsftype*]
-#   Virtual synchrony filter type
+#   Virtual synchrony filter type.
+#   Default: undef
 #
 # [*package_corosync*]
 #   Define if package corosync should be managed.
-#   Defaults to true
+#   Default: true
 #
 # [*package_crmsh*]
-#   Define if package corosync should be managed.
-#   Defaults to true in Debian-based systems, false otherwise
-#
-# [*version_corosync*]
-#   Define what version of corosync should be managed.
-#   Defaults to present
+#   Define if package crmsh should be managed.
+#   Default (Debian based): true
+#   Default (otherwise):    false
 #
 # [*package_pacemaker*]
 #   Define if package pacemaker should be managed.
-#   Defaults to true
+#   Default: true
 #
 # [*package_pcs*]
 #   Define if package pcs should be managed.
-#   Defaults to true on Red-hat based systems, false otherwise
+#   Default (Red Hat based):  true
+#   Default (otherwise):      false
 #
 # [*packageopts_corosync*]
 #   Additional install-options for the corosync package resource.
-#   Defaults to ['-t', 'jessie-backports'] on Jessie, undef otherwise.
+#   Default (Debian Jessie):  ['-t', 'jessie-backports']
+#   Default (otherwise):      undef
 #
 # [*packageopts_crmsh*]
 #   Additional install-options for the crmsh package resource.
-#   Defaults to ['-t', 'jessie-backports'] on Jessie, undef otherwise.
+#   Default (Debian Jessie):  ['-t', 'jessie-backports']
+#   Default (otherwise):      undef
 #
 # [*packageopts_pacemaker*]
 #   Additional install-options for the pacemaker package resource.
-#   Defaults to ['-t', 'jessie-backports'] on Jessie, undef otherwise.
+#   Default (Debian Jessie):  ['-t', 'jessie-backports']
+#   Default (otherwise):      undef
 #
 # [*packageopts_pcs*]
 #   Additional install-options for the pcs package resource.
-#   Defaults to ['-t', 'jessie-backports'] on Jessie, undef otherwise.
+#   Default (Debian Jessie):  ['-t', 'jessie-backports']
+#   Default (otherwise):      undef
 #
 # [*version_corosync*]
 #   Define what version of the corosync package should be installed.
-#   Defaults to present
+#   Default: 'present'
 #
 # [*version_crmsh*]
 #   Define what version of the crmsh package should be installed.
-#   Defaults to present
+#   Default: 'present'
 #
 # [*version_pacemaker*]
 #   Define what version of the pacemaker package should be installed.
-#   Defaults to present
+#   Default: 'present'
 #
 # [*version_pcs*]
 #   Define what version of the pcs package should be installed.
-#   Defaults to present
+#   Default: 'present'
 #
 # [*set_votequorum*]
 #   Set to true if corosync_votequorum should be used as quorum provider.
-#   Defaults to true on RedHat based operating systems.
-#   Defaults to true on Ubuntu version 14.04 or greater.
-#   Defaults to false on all other operating systems.
+#   Default (Red Hat based):    true
+#   Default (Ubuntu >= 14.04):  true
+#   Default (otherwise):        false
+#
+# [*votequorum_expected_votes*]
+#   Default: undef
 #
 # [*quorum_members*]
 #   Array of quorum member hostname. This is required if set_votequorum
 #   is set to true.
 #   You can also have an array of arrays to have multiple rings. In that case,
 #   each subarray matches a member IP addresses.
-#   Defaults to ['localhost']
+#   Default: ['localhost']
 #
 # [*quorum_members_ids*]
 #   Array of quorum member IDs. Persistent IDs are required for the dynamic
 #   config of a corosync cluster and when_set_votequorum is set to true.
 #   Should be used only with the quorum_members parameter.
-#   Defaults to undef
+#   Default: undef
 #
 # [*quorum_members_names*]
 #   Array of quorum member names. Persistent names are required when you
@@ -173,40 +192,49 @@
 #
 # [*token*]
 #   Time (in ms) to wait for a token
+#   Default: undef
 #
 # [*token_retransmits_before_loss_const*]
-#   How many token retransmits before forming a new configuration
+#   How many token retransmits before forming a new configuration.
+#   Default: undef
+#
+# [*compatibility*]
+#   Default: undef
 #
 # [*enable_corosync_service*]
 #   Whether the module should enable the corosync service.
+#   Default: true
 #
 # [*enable_pacemaker_service*]
 #   Whether the module should enable the pacemaker service.
+#   Default: true
 #
 # [*manage_pacemaker_service*]
 #   Whether the module should try to manage the pacemaker service in
 #   addition to the corosync service.
-#   Defaults to true on RedHat based operating systems version 7 or greater.
-#   Defaults to true on Ubuntu version 14.04 or greater.
-#   Defaults to false on all other operating systems.
+#   Default (Red Hat based >= 7): true
+#   Default (Ubuntu >= 14.04):    true
+#   Default (otherwise):          false
 #
 # [*enable_pcsd_service*]
 #   Whether the module should enable the pcsd service.
+#   Default: true
 #
 # [*manage_pcsd_service*]
 #   Whether the module should try to manage the pcsd service in addition to the
 #   corosync service.
 #   pcsd service is the GUI and the remote configuration interface.
-#   Defaults to false
+#   Default: false
 #
 # [*cluster_name*]
 #   This specifies the name of cluster and it's used for automatic
 #   generating of multicast address.
+#   Default: undef
 #
 # [*join*]
 #   This timeout specifies in milliseconds how long to wait for join messages
 #   in the membership protocol.
-#   Default to 50
+#   Default: undef
 #
 # [*consensus*]
 #   This timeout specifies in milliseconds how long to wait for consensus to be
@@ -214,22 +242,22 @@
 #   The minimum value for consensus must be 1.2 * token. This value will be
 #   automatically calculated at 1.2 * token if the user doesn't specify a
 #   consensus value.
-#   Defaults to false,
+#   Default: undef
 #
 # [*max_messages*]
 #   This constant specifies the maximum number of messages that may be sent by
 #   one processor on receipt of the token. The max_messages parameter is limited
 #   to 256000 / netmtu to prevent overflow of the kernel transmit buffers.
-#   Defaults to 17
+#   Default: undef
 #
 # [*test_corosync_config*]
-#   Wheter we should test new configuration files with `corosync -t`.
+#   Whether we should test new configuration files with `corosync -t`.
 #   Defaults to true on OS that allows that (requires corosync 2.3.4).
 #
 # === Examples
 #
 #  class { 'corosync':
-#    enable_secauth    => false,
+#    enable_secauth    => 'off',
 #    bind_address      => '192.168.2.10',
 #    multicast_address => '239.1.1.2',
 #  }
@@ -243,57 +271,56 @@
 # Copyright 2012, Puppet Labs, LLC.
 #
 class corosync(
-  $enable_secauth                      = $::corosync::params::enable_secauth,
-  $authkey_source                      = $::corosync::params::authkey_source,
-  $authkey                             = $::corosync::params::authkey,
-  $threads                             = $::corosync::params::threads,
-  $port                                = $::corosync::params::port,
-  $bind_address                        = $::corosync::params::bind_address,
-  $multicast_address                   = $::corosync::params::multicast_address,
-  $unicast_addresses                   = $::corosync::params::unicast_addresses,
-  $force_online                        = $::corosync::params::force_online,
-  $check_standby                       = $::corosync::params::check_standby,
-  $log_timestamp                       = $::corosync::params::log_timestamp,
-  $log_file                            = $::corosync::params::log_file,
-  $log_file_name                       = $::corosync::params::log_file_name,
-  $debug                               = $::corosync::params::debug,
-  $log_stderr                          = $::corosync::params::log_stderr,
-  $syslog_priority                     = $::corosync::params::syslog_priority,
-  $log_function_name                   = $::corosync::params::log_function_name,
-  $rrp_mode                            = $::corosync::params::rrp_mode,
-  $netmtu                              = $::corosync::params::netmtu,
-  $ttl                                 = $::corosync::params::ttl,
-  $vsftype                             = $::corosync::params::vsftype,
-  $package_corosync                    = $::corosync::params::package_corosync,
-  $package_crmsh                       = $::corosync::params::package_crmsh,
-  $package_pacemaker                   = $::corosync::params::package_pacemaker,
-  $package_pcs                         = $::corosync::params::package_pcs,
-  $packageopts_corosync                = $::corosync::params::package_install_options,
-  $packageopts_pacemaker               = $::corosync::params::package_install_options,
-  $packageopts_crmsh                   = $::corosync::params::package_install_options,
-  $packageopts_pcs                     = $::corosync::params::package_install_options,
-  $version_corosync                    = $::corosync::params::version_corosync,
-  $version_crmsh                       = $::corosync::params::version_crmsh,
-  $version_pacemaker                   = $::corosync::params::version_pacemaker,
-  $version_pcs                         = $::corosync::params::version_pcs,
-  $set_votequorum                      = $::corosync::params::set_votequorum,
-  $votequorum_expected_votes           = $::corosync::params::votequorum_expected_votes,
-  $quorum_members                      = ['localhost'],
-  $quorum_members_ids                  = undef,
-  $quorum_members_names                = undef,
-  $token                               = $::corosync::params::token,
-  $token_retransmits_before_loss_const = $::corosync::params::token_retransmits_before_loss_const,
-  $compatibility                       = $::corosync::params::compatibility,
-  $enable_corosync_service             = $::corosync::params::enable_corosync_service,
-  $enable_pacemaker_service            = $::corosync::params::enable_pacemaker_service,
-  $manage_pacemaker_service            = $::corosync::params::manage_pacemaker_service,
-  $enable_pcsd_service                 = $::corosync::params::enable_pcsd_service,
-  $manage_pcsd_service                 = false,
-  $cluster_name                        = $::corosync::params::cluster_name,
-  $join                                = $::corosync::params::join,
-  $consensus                           = $::corosync::params::consensus,
-  $max_messages                        = $::corosync::params::max_messages,
-  $test_corosync_config                = $::corosync::params::test_corosync_config,
+  Enum['on', 'off'] $enable_secauth                                           = $::corosync::params::enable_secauth,
+  Enum['file', 'string'] $authkey_source                                      = $::corosync::params::authkey_source,
+  String $authkey                                                             = $::corosync::params::authkey,
+  Optional[Integer] $threads                                                  = $::corosync::params::threads,
+  String $port                                                                = $::corosync::params::port,
+  String $bind_address                                                        = $::corosync::params::bind_address,
+  Optional[String] $multicast_address                                         = $::corosync::params::multicast_address,
+  Optional[Array] $unicast_addresses                                          = $::corosync::params::unicast_addresses,
+  Boolean $force_online                                                       = $::corosync::params::force_online,
+  Boolean $check_standby                                                      = $::corosync::params::check_standby,
+  Boolean $log_timestamp                                                      = $::corosync::params::log_timestamp,
+  Boolean $log_file                                                           = $::corosync::params::log_file,
+  Optional[Stdlib::Absolutepath] $log_file_name                               = $::corosync::params::log_file_name,
+  Boolean $debug                                                              = $::corosync::params::debug,
+  Boolean $log_stderr                                                         = $::corosync::params::log_stderr,
+  Enum['debug', 'info', 'notice', 'warning', 'err', 'emerg'] $syslog_priority = $::corosync::params::syslog_priority,
+  Boolean $log_function_name                                                  = $::corosync::params::log_function_name,
+  Optional[Enum['none', 'active', 'passive']] $rrp_mode                       = $::corosync::params::rrp_mode,
+  Optional[Integer] $netmtu                                                   = $::corosync::params::netmtu,
+  Optional[Integer[0,255]] $ttl                                               = $::corosync::params::ttl,
+  Optional[Enum['ykd', 'none']] $vsftype                                      = $::corosync::params::vsftype,
+  Boolean $package_corosync                                                   = $::corosync::params::package_corosync,
+  Boolean $package_crmsh                                                      = $::corosync::params::package_crmsh,
+  Boolean $package_pacemaker                                                  = $::corosync::params::package_pacemaker,
+  Boolean $package_pcs                                                        = $::corosync::params::package_pcs,
+  Optional[Array] $packageopts_corosync                                       = $::corosync::params::package_install_options,
+  Optional[Array] $packageopts_pacemaker                                      = $::corosync::params::package_install_options,
+  Optional[Array] $packageopts_crmsh                                          = $::corosync::params::package_install_options,
+  Optional[Array] $packageopts_pcs                                            = $::corosync::params::package_install_options,
+  String $version_corosync                                                    = $::corosync::params::version_corosync,
+  String $version_crmsh                                                       = $::corosync::params::version_crmsh,
+  String $version_pacemaker                                                   = $::corosync::params::version_pacemaker,
+  String $version_pcs                                                         = $::corosync::params::version_pcs,
+  Boolean $set_votequorum                                                     = $::corosync::params::set_votequorum,
+  Optional[Integer] $votequorum_expected_votes                                = $::corosync::params::votequorum_expected_votes,
+  Array $quorum_members                                                       = ['localhost'],
+  Optional[Array] $quorum_members_ids                                         = undef,
+  Optional[Integer] $token                                                    = $::corosync::params::token,
+  Optional[Integer] $token_retransmits_before_loss_const                      = $::corosync::params::token_retransmits_before_loss_const,
+  Optional[String] $compatibility                                             = $::corosync::params::compatibility,
+  Boolean $enable_corosync_service                                            = $::corosync::params::enable_corosync_service,
+  Boolean $enable_pacemaker_service                                           = $::corosync::params::enable_pacemaker_service,
+  Boolean $manage_pacemaker_service                                           = $::corosync::params::manage_pacemaker_service,
+  Boolean $enable_pcsd_service                                                = $::corosync::params::enable_pcsd_service,
+  Boolean $manage_pcsd_service                                                = false,
+  Optional[String] $cluster_name                                              = $::corosync::params::cluster_name,
+  Optional[Integer] $join                                                     = $::corosync::params::join,
+  Optional[Integer] $consensus                                                = $::corosync::params::consensus,
+  Optional[Integer] $max_messages                                             = $::corosync::params::max_messages,
+  Boolean $test_corosync_config                                               = $::corosync::params::test_corosync_config,
 ) inherits ::corosync::params {
 
   if $set_votequorum and !$quorum_members {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -369,7 +369,7 @@ class corosync(
 
   # You have to specify at least one of the following parameters:
   # $multicast_address or $unicast_address or $cluster_name
-  if $multicast_address == 'UNSET' and $unicast_addresses == 'UNSET' and !$cluster_name {
+  if !$multicast_address and !$unicast_addresses and !$cluster_name {
       fail('You must provide a value for multicast_address, unicast_address or cluster_name.')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -324,15 +324,15 @@ class corosync(
   Boolean $test_corosync_config                                               = $::corosync::params::test_corosync_config,
 ) inherits ::corosync::params {
 
-  if $set_votequorum and !$quorum_members {
+  if $set_votequorum and empty($quorum_members) {
     fail('set_votequorum is true, but no quorum_members have been passed.')
   }
 
-  if $quorum_members_names and !$quorum_members {
+  if $quorum_members_names and empty($quorum_members) {
     fail('quorum_members_names may not be used without the quorum_members.')
   }
 
-  if $quorum_members_ids and !$quorum_members {
+  if $quorum_members_ids and empty($quorum_members) {
     fail('quorum_members_ids may not be used without the quorum_members.')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -276,7 +276,7 @@ class corosync(
   String $authkey                                                             = $::corosync::params::authkey,
   Optional[Integer] $threads                                                  = $::corosync::params::threads,
   String $port                                                                = $::corosync::params::port,
-  String $bind_address                                                        = $::corosync::params::bind_address,
+  Variant[String, Array] $bind_address                                        = $::corosync::params::bind_address,
   Optional[String] $multicast_address                                         = $::corosync::params::multicast_address,
   Optional[Array] $unicast_addresses                                          = $::corosync::params::unicast_addresses,
   Boolean $force_online                                                       = $::corosync::params::force_online,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,12 +1,12 @@
 class corosync::params {
-  $enable_secauth                      = true
+  $enable_secauth                      = 'on'
   $authkey_source                      = 'file'
   $authkey                             = '/etc/puppet/ssl/certs/ca.pem'
   $threads                             = undef
   $port                                = '5405'
   $bind_address                        = $::ipaddress
-  $multicast_address                   = 'UNSET'
-  $unicast_addresses                   = 'UNSET'
+  $multicast_address                   = undef
+  $unicast_addresses                   = undef
   $force_online                        = false
   $check_standby                       = false
   $log_timestamp                       = false
@@ -18,11 +18,11 @@ class corosync::params {
   $log_function_name                   = false
   $rrp_mode                            = undef
   $netmtu                              = undef
-  $ttl                                 = false
+  $ttl                                 = undef
   $vsftype                             = undef
   $token                               = undef
   $token_retransmits_before_loss_const = undef
-  $votequorum_expected_votes           = false
+  $votequorum_expected_votes           = undef
   $cluster_name                        = undef
   $join                                = undef
   $consensus                           = undef

--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.8.7 < 5.0.0"
+      "version_requirement": ">= 4.7.1 < 5.0.0"
     }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     }
   ],
   "tags": [

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -175,7 +175,7 @@ describe 'corosync' do
     context 'when unicast is used' do
       before do
         params.merge!(
-          multicast_address: 'UNSET',
+          multicast_address: :undef,
           unicast_addresses: ['192.168.1.1', '192.168.1.2']
         )
       end
@@ -234,7 +234,7 @@ describe 'corosync' do
       context 'witout secauth' do
         before do
           params.merge!(
-            enable_secauth: false
+            enable_secauth: 'off'
           )
         end
 
@@ -311,7 +311,7 @@ describe 'corosync' do
     context 'when multicast_address, unicast_addresses and cluster_name are not set' do
       before do
         params.merge!(
-          multicast_address: 'UNSET'
+          multicast_address: :undef
         )
       end
 
@@ -326,7 +326,7 @@ describe 'corosync' do
     context 'when only cluster_name is set' do
       before do
         params.merge!(
-          multicast_address: 'UNSET',
+          multicast_address: :undef,
           cluster_name: 'mycluster'
         )
       end
@@ -410,22 +410,6 @@ describe 'corosync' do
       end
     end
 
-    context 'when log_file_name is not an absolute path' do
-      before do
-        params.merge!(
-          log_file: true,
-          log_file_name: 'corosync.log'
-        )
-      end
-
-      it 'raises error' do
-        is_expected.to raise_error(
-          Puppet::Error,
-          %r{is not an absolute path}
-        )
-      end
-    end
-
     context 'when log_file is disabled' do
       before do
         params.merge!(
@@ -448,12 +432,11 @@ describe 'corosync' do
     {
       'threads' => 10,
       'rrp_mode' => 'none',
-      'netmtu' => '1500',
+      'netmtu' => 1500,
       'token' => 3000,
       'vsftype' => 'none',
       'token_retransmits_before_loss_const' => 10,
-      'join' => '50',
-      'consensus' => 'false',
+      'join' => 50,
       'max_messages' => 17,
       'compatibility' => 'whitetank'
     }.each do |optional_parameter, possible_value|
@@ -516,22 +499,6 @@ describe 'corosync' do
         it "does not install #{package}" do
           is_expected.not_to contain_package(package)
         end
-      end
-    end
-
-    context 'when set_quorum is true and quorum_members is not set' do
-      before do
-        params.merge!(
-          set_votequorum: true,
-          quorum_members: false
-        )
-      end
-
-      it 'raises error' do
-        is_expected.to raise_error(
-          Puppet::Error,
-          %r{set_votequorum is true, but no quorum_members have been passed.}
-        )
       end
     end
 

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -231,7 +231,7 @@ describe 'corosync' do
         end
       end
 
-      context 'witout secauth' do
+      context 'without secauth' do
         before do
           params.merge!(
             enable_secauth: 'off'

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -502,6 +502,22 @@ describe 'corosync' do
       end
     end
 
+    context 'when set_quorum is true and quorum_members is not set' do
+      before do
+        params.merge!(
+          set_votequorum: true,
+          quorum_members: []
+        )
+      end
+
+      it 'raises error' do
+        is_expected.to raise_error(
+          Puppet::Error,
+          %r{set_votequorum is true, but no quorum_members have been passed.}
+        )
+      end
+    end
+
     context 'when configuring defaults for logging' do
       it 'configures stderr, syslog priority, func names' do
         is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -37,11 +37,11 @@ totem {
 <% unless @netmtu.nil? -%>
   netmtu:                              <%= @netmtu %>
 <% end -%>
-  secauth:                             <%= @enable_secauth_real %>
+  secauth:                             <%= @enable_secauth %>
 <% unless @threads.nil? -%>
   threads:                             <%= @threads %>
 <% end -%>
-<% if @unicast_addresses != 'UNSET' -%>
+<% unless @unicast_addresses.nil? -%>
   transport:                           udpu
 <% Array(@unicast_addresses.first).each_index do |interface| -%>
   interface {
@@ -63,7 +63,7 @@ totem {
   interface {
     ringnumber:  <%= i %>
     bindnetaddr: <%= [@bind_address].flatten[i] %>
-<% if @multicast_address == 'UNSET' -%>
+<% if @multicast_address.nil? -%>
 <% elsif [@multicast_address].flatten[i] == 'broadcast' -%>
     broadcast:   yes
 <% else -%>


### PR DESCRIPTION
Add data types to init.pp, adjust default values in params.pp, and update description in init.pp. Remove 'validate_' functions from init.pp.

Values in 'corosync_spec.rb' were adjusted accordingly.

Also solves #322 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
