### PR TITLE
Add log subsystem support with new param $log_subsystem

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,10 @@
 #   True/false parameter specifying whether Corosync should log called funcions
 #   names to. Defaults to False.
 #
+# [*log_subsystem*]
+#   Hash parameter that adds specific log configurations based on logging
+#   subsystem. Defaults to nil.
+#
 # [*rrp_mode*]
 #   Mode of redundant ring. May be none, active, or passive.
 #
@@ -246,6 +250,7 @@ class corosync(
   $log_stderr                          = $::corosync::params::log_stderr,
   $syslog_priority                     = $::corosync::params::syslog_priority,
   $log_function_name                   = $::corosync::params::log_function_name,
+  $log_subsystem                       = undef,
   $rrp_mode                            = $::corosync::params::rrp_mode,
   $netmtu                              = $::corosync::params::netmtu,
   $ttl                                 = $::corosync::params::ttl,
@@ -321,14 +326,19 @@ class corosync(
   validate_bool($force_online)
   validate_bool($check_standby)
   validate_bool($log_file)
-  if getvar('log_file_name') and $log_file == true {
-    validate_absolute_path($log_file_name)
-  }
-  validate_bool($log_timestamp)
   validate_bool($debug)
   validate_bool($log_stderr)
   validate_re($syslog_priority, '^(debug|info|notice|warning|err|emerg)$')
   validate_bool($log_function_name)
+  if $log_subsystem {
+    [$log_subsystem].each |Hash $subsystem| {
+      validate_string($subsystem[name])
+      validate_bool($subsystem[debug])
+      validate_bool($subsystem[log_file])
+      validate_bool($subsystem[syslog])
+    }
+  }
+
 
   # You have to specify at least one of the following parameters:
   # $multicast_address or $unicast_address or $cluster_name

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -106,7 +106,7 @@ logging {
 <% end -%>
   debug:           <%= @debug ? 'on' : 'off' %>
 <% [@log_subsystem].each do |subsys| -%>
-  logger subsys {
+  logger_subsys {
     subsys: <%= subsys['name'] %>
 <% if subsys['log_file'] -%>
     to_logfile:      yes

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -105,6 +105,21 @@ logging {
   function_name:   on
 <% end -%>
   debug:           <%= @debug ? 'on' : 'off' %>
+<% [@log_subsystem].each do |subsys| -%>
+  logger subsys {
+    subsys: <%= subsys['name'] %>
+<% if subsys['log_file'] -%>
+    to_logfile:      yes
+<% if @log_file_name -%>
+    logfile:         <%= @log_file_name %>
+<% end -%>
+<% else -%>
+    to_logfile:      no
+<% end -%>
+    to_syslog:       <%= subsys['syslog'] ? 'on' : 'off' %>
+    debug:           <%= subsys['debug'] ? 'on' : 'off' %>
+  }
+<% end -%>
 }
 
 <% if @set_votequorum -%>


### PR DESCRIPTION
Add additional class parameter to `::corosync` which allows to do give more detailed logging options to different log subsystems.