### PR TITLE
Define the names of the quorum members

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,6 +166,11 @@
 #   Should be used only with the quorum_members parameter.
 #   Defaults to undef
 #
+# [*quorum_members_names*]
+#   Array of quorum member names. Persistent names are required when you
+#   define IP addresses in quorum_members.
+#   Defaults to undef
+#
 # [*token*]
 #   Time (in ms) to wait for a token
 #
@@ -266,6 +271,7 @@ class corosync(
   $votequorum_expected_votes           = $::corosync::params::votequorum_expected_votes,
   $quorum_members                      = ['localhost'],
   $quorum_members_ids                  = undef,
+  $quorum_members_names                = undef,
   $token                               = $::corosync::params::token,
   $token_retransmits_before_loss_const = $::corosync::params::token_retransmits_before_loss_const,
   $compatibility                       = $::corosync::params::compatibility,
@@ -280,6 +286,10 @@ class corosync(
 
   if $set_votequorum and !$quorum_members {
     fail('set_votequorum is true, but no quorum_members have been passed.')
+  }
+
+  if $quorum_members_names and !$quorum_members {
+    fail('quorum_members_names may not be used without the quorum_members.')
   }
 
   if $quorum_members_ids and !$quorum_members {

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -50,6 +50,20 @@ describe 'corosync' do
             %r{ring0_addr\: node2\.test\.org\n\s*nodeid: 11}
           )
         end
+
+        it 'supports persistent node names' do
+          params[:quorum_members] = ['192.168.0.1', '192.168.0.2']
+          params[:quorum_members_names] = ['node1.test.org', 'node2.test.org']
+          is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{nodelist}
+          )
+          is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{ring0_addr\: 192\.168\.0\.1\n\s*nodeid: 1\n\s*name: node1\.test\.org}
+          )
+          is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{ring0_addr\: 192\.168\.0\.2\n\s*nodeid: 2\n\s*name: node2\.test\.org}
+          )
+        end
       end
 
       context 'when quorum_members is set to an array with 3 items' do
@@ -199,6 +213,20 @@ describe 'corosync' do
           )
           is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
             %r{ring0_addr\: node2\.test\.org\n\s*nodeid: 11}
+          )
+        end
+
+        it 'supports persistent node names' do
+          params[:quorum_members] = ['192.168.0.1', '192.168.0.2']
+          params[:quorum_members_names] = ['node1.test.org', 'node2.test.org']
+          is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{nodelist}
+          )
+          is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{ring0_addr\: 192\.168\.0\.1\n\s*nodeid: 1\n\s*name: node1\.test\.org}
+          )
+          is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{ring0_addr\: 192\.168\.0\.2\n\s*nodeid: 2\n\s*name: node2\.test\.org}
           )
         end
       end

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -133,6 +133,9 @@ nodelist {
 <% else -%>
     nodeid: <%= [@quorum_members_ids].flatten[i] %>
 <% end -%>
+<% if not @quorum_members_names.nil? -%>
+    name: <%= [@quorum_members_names].flatten[i] %>
+<% end -%>
   }
 <% end -%>
 }


### PR DESCRIPTION
Persistent names are required when you define IP addesses in
quorum_members. Otherwise, crm_node --name-for-id number can't find the
name of the member.

https://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-node-name.html

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
