### PR TITLE
Change usage of CIB shadow for pcs

### DIFF
--- a/lib/puppet/provider/cs_commit/pcs.rb
+++ b/lib/puppet/provider/cs_commit/pcs.rb
@@ -8,7 +8,6 @@ rescue LoadError
 end
 
 Puppet::Type.type(:cs_commit).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync::Provider::Pcs) do
-  commands crm_shadow: 'crm_shadow'
   commands cibadmin: 'cibadmin'
   # Required for block_until_ready
   commands pcs: 'pcs'
@@ -19,10 +18,11 @@ Puppet::Type.type(:cs_commit).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync
   end
 
   def commit
-    PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib(['crm_shadow', '--force', '--commit', @resource[:name]])
+    cib_path = File.join(Puppet[:vardir], 'shadow.' + @resource[:name])
+    PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib([command(:pcs), 'cluster', 'cib-push', cib_path, 'diff-against=' + cib_path + '.ori'])
     # We run the next command in the CIB directly by purpose:
     # We commit the shadow CIB with the admin_epoch it was created.
-    PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib(['cibadmin', '--modify', '--xml-text', '<cib admin_epoch="admin_epoch++"/>'])
+    PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib([command(:cibadmin), '--modify', '--xml-text', '<cib admin_epoch="admin_epoch++"/>'])
     # Next line is for indempotency
     PuppetX::Voxpupuli::Corosync::Provider::Pcs.sync_shadow_cib(@resource[:name], true)
   end

--- a/lib/puppet/provider/cs_group/crm.rb
+++ b/lib/puppet/provider/cs_group/crm.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:cs_group).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
     instances = []
 
     cmd = [command(:crm), 'configure', 'show', 'xml']
-    raw, = PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib(cmd)
+    raw, = PuppetX::Voxpupuli::Corosync::Provider::Crmsh.run_command_in_cib(cmd)
     doc = REXML::Document.new(raw)
 
     REXML::XPath.each(doc, '//group') do |e|

--- a/lib/puppet/provider/cs_location/pcs.rb
+++ b/lib/puppet/provider/cs_location/pcs.rb
@@ -84,10 +84,10 @@ Puppet::Type.type(:cs_location).provide(:pcs, parent: PuppetX::Voxpupuli::Corosy
     return if @property_hash.empty?
 
     # Remove existing location
-    cmd = ['pcs', 'constraint', 'remove', @resource[:name]]
+    cmd = [command(:pcs), 'constraint', 'remove', @resource[:name]]
     PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib(cmd, @resource[:cib], false)
     unless @property_hash[:node_name].nil?
-      cmd = ['pcs', 'constraint', 'location', 'add', @property_hash[:name], @property_hash[:primitive], @property_hash[:node_name], @property_hash[:score]]
+      cmd = [command(:pcs), 'constraint', 'location', 'add', @property_hash[:name], @property_hash[:primitive], @property_hash[:node_name], @property_hash[:score]]
       cmd << "resource-discovery=#{@property_hash[:resource_discovery]}" unless @property_hash[:resource_discovery].nil?
       PuppetX::Voxpupuli::Corosync::Provider::Pcs.run_command_in_cib(cmd, @resource[:cib])
     end

--- a/lib/puppet/provider/cs_shadow/crm.rb
+++ b/lib/puppet/provider/cs_shadow/crm.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:cs_shadow).provide(:crm, parent: PuppetX::Voxpupuli::Corosync
 
   # Need this available at the provider level, for types
   def get_epoch(cib = nil)
-    PuppetX::Voxpupuli::Corosync::Provider::Pcs.get_epoch(cib)
+    PuppetX::Voxpupuli::Corosync::Provider::Crmsh.get_epoch(cib)
   end
 
   def epoch

--- a/lib/puppet/provider/cs_shadow/pcs.rb
+++ b/lib/puppet/provider/cs_shadow/pcs.rb
@@ -8,7 +8,6 @@ rescue LoadError
 end
 
 Puppet::Type.type(:cs_shadow).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync::Provider::Pcs) do
-  commands crm_shadow: 'crm_shadow'
   commands cibadmin: 'cibadmin'
   # Required for block_until_ready
   commands pcs: 'pcs'

--- a/lib/puppet_x/voxpupuli/corosync/provider/cib_helper.rb
+++ b/lib/puppet_x/voxpupuli/corosync/provider/cib_helper.rb
@@ -11,12 +11,7 @@ class PuppetX::Voxpupuli::Corosync::Provider::CibHelper < Puppet::Provider
   # Yep, that's right we are parsing XML...FUN! (It really wasn't that bad)
   require 'rexml/document'
 
-  def self.run_command_in_cib(cmd, cib = nil, failonfail = true)
-    custom_environment = if cib.nil?
-                           { combine: true }
-                         else
-                           { combine: true, custom_environment: { 'CIB_shadow' => cib } }
-                         end
+  def self._run_command_in_cib(cmd, cib = nil, failonfail = true, custom_environment = { combine: true })
     debug("Executing #{cmd} in the CIB") if cib.nil?
     debug("Executing #{cmd} in the shadow CIB \"#{cib}\"") unless cib.nil?
     raw = Puppet::Util::Execution.execute(cmd, { failonfail: failonfail }.merge(custom_environment))
@@ -116,13 +111,7 @@ class PuppetX::Voxpupuli::Corosync::Provider::CibHelper < Puppet::Provider
     rule_parameters
   end
 
-  def self.sync_shadow_cib(cib, failondeletefail = false)
-    run_command_in_cib(['crm_shadow', '--force', '--delete', cib], nil, failondeletefail)
-    run_command_in_cib(['crm_shadow', '--batch', '--create', cib])
-  end
-
-  def self.get_epoch(cib = nil)
-    cmd = [command(:cibadmin), '--query', '--xpath', '/cib', '-l', '-n']
+  def self._get_epoch(cmd, cib = nil)
     raw, status = run_command_in_cib(cmd, cib, false)
     return :absent if status.nonzero?
     doc = REXML::Document.new(raw)


### PR DESCRIPTION
The usage of CIB_shadow environment variable is not supported in pcs.
The recommendation is to use an alternative file instead of active CIB.

Example:
    pcs cluster cib original.xml
    cp original.xml new.xml
    pcs -f new.xml constraint location apache prefers node2
    pcs cluster cib-push new.xml diff-against=original.xml

See RHBZ#1497736

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
