### PR TITLE
Configure debian 8 systems for acceptance tests

### DIFF
--- a/spec/acceptance/nodesets/docker/debian-8.yml
+++ b/spec/acceptance/nodesets/docker/debian-8.yml
@@ -10,7 +10,6 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'echo deb http://ftp.debian.org/debian jessie-backports main >> /etc/apt/sources.list'
       - 'apt-get update && apt-get install -y cron locales-all net-tools wget'
       - 'rm -f /usr/sbin/policy-rc.d'
       - 'systemctl mask getty@tty1.service getty-static.service'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -35,6 +35,14 @@ RSpec.configure do |c|
 
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
+
+      # For Debian 8 "jessie", we need
+      # - pacemaker and crmsh delivered in jessie-backports only
+      # - openhpid post-install may fail (https://bugs.debian.org/785287)
+      if fact('lsbdistcodename') == 'jessie'
+        on host, 'echo deb http://ftp.debian.org/debian jessie-backports main >> /etc/apt/sources.list'
+        on host, 'apt-get update && apt-get install -y openhpid'
+      end
     end
   end
 end


### PR DESCRIPTION
* pacemaker and crmsh are delivered in jessie-backports
* openhpid post-install may fail (#408)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
