### PR TITLE
support Debian 9 (#404)

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,22 +1,22 @@
 ---
 .travis.yml:
   extras:
-  - rvm: 2.3.1
+  - rvm: 2.4.2
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-7
     services: docker
     sudo: required
-    bundler_args: --without development
-  - rvm: 2.3.1
-    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/debian-8
+    bundler_args: --without development release
+  - rvm: 2.4.2
+    env: PUPPET_INSTALL_TYPE=agent CHECK=beaker BEAKER_debug=true BEAKER_set=docker/debian-9 BEAKER_VERSION='~> 3.27'
     services: docker
     sudo: required
     bundler_args: --without development
-  - rvm: 2.3.1
+  - rvm: 2.4.2
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
     services: docker
     sudo: required
     bundler_args: --without development
-  - rvm: 2.3.1
+  - rvm: 2.4.2
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/ubuntu-16.04
     services: docker
     sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,22 +27,22 @@ matrix:
   - rvm: 2.4.2
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
-  - rvm: 2.3.1
+  - rvm: 2.4.2
     bundler_args: --without development
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-7
     services: docker
     sudo: required
-  - rvm: 2.3.1
-    bundler_args: --without development
-    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/debian-8
+  - rvm: 2.4.2
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent CHECK=beaker BEAKER_debug=true BEAKER_set=docker/debian-9 BEAKER_VERSION='~> 3.27'
     services: docker
     sudo: required
-  - rvm: 2.3.1
+  - rvm: 2.4.2
     bundler_args: --without development
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
     services: docker
     sudo: required
-  - rvm: 2.3.1
+  - rvm: 2.4.2
     bundler_args: --without development
     env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/ubuntu-16.04
     services: docker

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,8 +69,12 @@ class corosync::params {
           if versioncmp($::operatingsystemrelease, '8') >= 0 {
             $set_votequorum = true
             $manage_pacemaker_service = true
-            $package_install_options = ['-t', 'jessie-backports']
             $test_corosync_config = true
+            if versioncmp($::operatingsystemrelease, '8') == 0 {
+              $package_install_options = ['-t', 'jessie-backports']
+            } else {
+              $package_install_options = undef
+            }
           } else {
             $set_votequorum = false
             $manage_pacemaker_service = false

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
This adds support to Debian 9
As currently implemented, it drops Debian 8 acceptance tests, though we could leave it as 8, or run both.