### PR TITLE
Remove `bindnetaddr` when $bind_address => 'UNSET'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,8 @@
 #
 # [*bind_address*]
 #   The ip address we are going to bind the corosync daemon too.
-#   Can be specified as an array to have multiple rings.
+#   Can be specified as an array to have multiple rings or can have the value
+#   'UNSET' in order to remove the `bindnetaddr` corosync directive.
 #   Default: $::ipaddress
 #
 # [*port*]
@@ -289,7 +290,7 @@ class corosync(
   Stdlib::Absolutepath $authkey                           = $corosync::params::authkey,
   Optional[Integer] $threads                              = undef,
   Integer[0,65535] $port                                  = $corosync::params::port,
-  Corosync::IpStringIp $bind_address                      = $corosync::params::bind_address,
+  Variant[Corosync::IpStringIp, Enum['UNSET']] $bind_address  = $corosync::params::bind_address,
   Optional[Stdlib::Compat::Ip_address] $multicast_address = undef,
   Optional[Array] $unicast_addresses                      = undef,
   Boolean $force_online                                   = $corosync::params::force_online,

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -312,6 +312,15 @@ describe 'corosync' do
       end
     end
 
+    context 'when bind_address is UNSET' do
+      it do
+        params[:bind_address] = 'UNSET'
+        is_expected.to contain_file('/etc/corosync/corosync.conf').without_content(
+          %r{bindnetaddr:}m
+        )
+      end
+    end
+
     context 'when cluster_name is set' do
       before do
         params.merge!(

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -51,7 +51,9 @@ totem {
     }
 <% end -%>
     ringnumber:  <%= interface %>
+<% if @bind_address != 'UNSET' -%>
     bindnetaddr: <%= Array(@bind_address)[interface] %>
+<% end -%>
     mcastport:   <%= Array(@port)[interface] || @port %>
 <% if @ttl -%>
     ttl:         <%= Array(@ttl)[interface] || @ttl %>
@@ -62,7 +64,9 @@ totem {
 <% [@bind_address].flatten.each_index do |i| -%>
   interface {
     ringnumber:  <%= i %>
+<% if @bind_address != 'UNSET' -%>
     bindnetaddr: <%= [@bind_address].flatten[i] %>
+<% end -%>
 <% if @multicast_address.nil? -%>
 <% elsif [@multicast_address].flatten[i] == 'broadcast' -%>
     broadcast:   yes


### PR DESCRIPTION
This small (dummy) patch address issue #421.
I would be glad to discuss about this patch and its implementation.