### PR TITLE
Added manage corosync feature

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -210,13 +210,17 @@
 #   Whether the module should enable the corosync service.
 #   Default: true
 #
+# [*manage_corosync_service*]
+#   Whether the module should try to manage the corosync service. If set to
+#   false, the service will need to be specified in the catalog elsewhere.
+#   Default: true
+#
 # [*enable_pacemaker_service*]
 #   Whether the module should enable the pacemaker service.
 #   Default: true
 #
 # [*manage_pacemaker_service*]
-#   Whether the module should try to manage the pacemaker service in
-#   addition to the corosync service.
+#   Whether the module should try to manage the pacemaker service.
 #   Default (Red Hat based >= 7): true
 #   Default (Ubuntu >= 14.04):    true
 #   Default (otherwise):          false
@@ -322,6 +326,7 @@ class corosync(
   Optional[Integer] $token_retransmits_before_loss_const  = undef,
   Optional[String] $compatibility                         = undef,
   Boolean $enable_corosync_service                        = $corosync::params::enable_corosync_service,
+  Boolean $manage_corosync_service                        = $corosync::params::manage_corosync_service,
   Boolean $enable_pacemaker_service                       = $corosync::params::enable_pacemaker_service,
   Boolean $manage_pacemaker_service                       = $corosync::params::manage_pacemaker_service,
   Boolean $enable_pcsd_service                            = $corosync::params::enable_pcsd_service,
@@ -515,9 +520,11 @@ class corosync(
     }
   }
 
-  service { 'corosync':
-    ensure    => running,
-    enable    => $enable_corosync_service,
-    subscribe => File[ [ '/etc/corosync/corosync.conf', '/etc/corosync/service.d' ] ],
+  if $manage_corosync_service {
+    service { 'corosync':
+      ensure    => running,
+      enable    => $enable_corosync_service,
+      subscribe => File[ [ '/etc/corosync/corosync.conf', '/etc/corosync/service.d' ] ],
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class corosync::params {
   $version_pacemaker                   = 'present'
   $version_pcs                         = 'present'
   $enable_corosync_service             = true
+  $manage_corosync_service             = true
   $enable_pacemaker_service            = true
   $enable_pcsd_service                 = true
 

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -9,6 +9,24 @@ describe 'corosync' do
   shared_examples_for 'corosync' do
     it { is_expected.to compile.with_all_deps }
 
+    it 'does manage the corosync service' do
+      is_expected.to contain_service('corosync').with(
+        ensure: 'running'
+      )
+    end
+
+    context 'when manage_corosync_service is false' do
+      before do
+        params.merge!(
+          manage_corosync_service: false
+        )
+      end
+
+      it 'is not managing corosync service' do
+        is_expected.not_to compile
+      end
+    end
+
     context 'when set_votequorum is true' do
       before do
         params.merge!(


### PR DESCRIPTION
There are instances where one doesn't want the corosync service to be started automatically, which puppet will do on first run with the default manifest.  This change gives the ability to manage the corosync service with your own settings, and also mentions the user will be responsible for ensuring there is a corosync service in their catalog somewhere else, or else the module will fail.

Also included basic spec tests for the change.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
