### PR TITLE
Fix variable type to allow authkey to be a string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -282,7 +282,7 @@
 class corosync(
   Boolean $enable_secauth                                 = $corosync::params::enable_secauth,
   Enum['file', 'string'] $authkey_source                  = $corosync::params::authkey_source,
-  Stdlib::Absolutepath $authkey                           = $corosync::params::authkey,
+  Variant[Stdlib::Absolutepath,String[1]] $authkey        = $corosync::params::authkey,
   Optional[Integer] $threads                              = undef,
   Integer[0,65535] $port                                  = $corosync::params::port,
   Corosync::IpStringIp $bind_address                      = $corosync::params::bind_address,

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -308,6 +308,29 @@ describe 'corosync' do
       end
     end
 
+    context 'when authkey is a string' do
+      before do
+        params.merge!(
+          authkey_source: 'string',
+          authkey: 'mysecretkey'
+        )
+      end
+      it 'should deploy authkey file' do
+        is_expected.to contain_file('/etc/corosync/authkey').with_content('mysecretkey')
+      end
+    end
+
+    context 'when authkey is a file' do
+      before do
+        params.merge!(
+          authkey: '/etc/pki/tls/private/corosync.key'
+        )
+      end
+      it 'should deploy authkey file' do
+        is_expected.to contain_file('/etc/corosync/authkey').with_source('/etc/pki/tls/private/corosync.key')
+      end
+    end
+
     context 'when multicast_address, unicast_addresses and cluster_name are not set' do
       before do
         params.merge!(

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -315,7 +315,7 @@ describe 'corosync' do
           authkey: 'mysecretkey'
         )
       end
-      it 'should deploy authkey file' do
+      it 'deploys authkey file' do
         is_expected.to contain_file('/etc/corosync/authkey').with_content('mysecretkey')
       end
     end
@@ -326,7 +326,7 @@ describe 'corosync' do
           authkey: '/etc/pki/tls/private/corosync.key'
         )
       end
-      it 'should deploy authkey file' do
+      it 'deploys authkey file' do
         is_expected.to contain_file('/etc/corosync/authkey').with_source('/etc/pki/tls/private/corosync.key')
       end
     end


### PR DESCRIPTION
This is related to PR #69 which introduced the capability of corosync class to take `authkey` as a string if `authkey_source` is set to 'string'.

Problem appeared at commit 42e13c76bc29027f6406199b9ab260c009157f8e when switching to Puppet 4 data types: `$authkey` was assigned a Stdlib::AbsolutePath data type.