### PR TITLE
member section is deprecated in favor of nodelist

### DIFF
--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -275,7 +275,7 @@ describe 'corosync' do
 
         it 'configures the ring properly' do
           is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
-            %r{interface.*memberaddr: 10\.0\.0\.1.*memberaddr: 10\.0\.0\.2.*ringnumber:\s+0.*bindnetaddr: 10\.0\.0\.1}m
+            %r{interface.*memberaddr: 10\.0\.0\.1.*memberaddr: 10\.0\.0\.2.*bindnetaddr: 10\.0\.0\.1.*ringnumber:\s+0}m
           )
         end
       end
@@ -298,7 +298,7 @@ describe 'corosync' do
 
         it 'configures the rings properly' do
           is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
-            %r{interface.*memberaddr: 10\.0\.0\.1.*memberaddr: 10\.0\.0\.2.*ringnumber:\s+0.*bindnetaddr: 10\.0\.0\.1.*interface.*memberaddr: 10\.0\.1\.1.*memberaddr: 10\.0\.1\.2.*ringnumber:\s+1.*bindnetaddr: 10\.0\.1\.1}m
+            %r{interface.*memberaddr: 10\.0\.0\.1.*memberaddr: 10\.0\.0\.2.*bindnetaddr: 10\.0\.0\.1.*ringnumber:\s+0.*interface.*memberaddr: 10\.0\.1\.1.*memberaddr: 10\.0\.1\.2.*bindnetaddr: 10\.0\.1\.1.*ringnumber:\s+1}m
           )
         end
       end

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -45,13 +45,15 @@ totem {
   transport:                           udpu
 <% Array(@unicast_addresses.first).each_index do |interface| -%>
   interface {
+<% if not @set_votequorum -%>
 <% Array(Array(@unicast_addresses.map{|x| Array(x).flatten}).transpose[interface]).each do |addr| -%>
     member {
       memberaddr: <%= addr %>
     }
 <% end -%>
-    ringnumber:  <%= interface %>
     bindnetaddr: <%= Array(@bind_address)[interface] %>
+<% end -%>
+    ringnumber:  <%= interface %>
     mcastport:   <%= Array(@port)[interface] || @port %>
 <% if @ttl -%>
     ttl:         <%= Array(@ttl)[interface] || @ttl %>


### PR DESCRIPTION
With recent release of corosync, it is recommended to migrate config
file to nodelist because member section is deprecated.

bindnetaddr might also conflicts with nodelist, so we remove bindnetaddr
if nodelist exists.

We rely on the value of set_votequorum to remove member section and
bindnetaddr from corosync.conf. This parameter is tied to quorum_members
in the corosync class.

spec: swap bindnetaddr and ringnumber in corosync.conf

Fix #421 and #422

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
