### PR TITLE
Multicast parameter fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,7 +280,7 @@ class corosync(
   Optional[Integer] $threads                                         = undef,
   Optional[Variant[Stdlib::Port, Array[Stdlib::Port]]] $port         = $corosync::params::port,
   Corosync::IpStringIp $bind_address                                 = $corosync::params::bind_address,
-  Optional[Stdlib::IP::Address] $multicast_address                   = undef,
+  Optional[Corosync::IpStringIp] $multicast_address                  = undef,
   Optional[Array] $unicast_addresses                                 = undef,
   Boolean $force_online                                              = $corosync::params::force_online,
   Boolean $check_standby                                             = $corosync::params::check_standby,
@@ -329,8 +329,8 @@ class corosync(
   Boolean $test_corosync_config                                      = $corosync::params::test_corosync_config,
 ) inherits ::corosync::params {
 
-  if $set_votequorum and empty($quorum_members) {
-    fail('set_votequorum is true, but no quorum_members have been passed.')
+  if $set_votequorum and (empty($quorum_members) and empty($multicast_address)) {
+    fail('set_votequorum is true, but neither quorum_members were passed nor was multicast specified.')
   }
 
   if $quorum_members_names and empty($quorum_members) {

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -534,11 +534,33 @@ describe 'corosync' do
         )
       end
 
-      it 'raises error' do
-        is_expected.to raise_error(
-          Puppet::Error,
-          %r{set_votequorum is true, but no quorum_members have been passed.}
-        )
+      context 'when multicast_address is set' do
+        before do
+          params.merge!(
+            multicast_address: '10.0.0.1'
+          )
+        end
+
+        it 'does not contain nodelist' do
+          is_expected.not_to contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{nodelist}
+          )
+        end
+      end
+
+      context 'when multicast_address is not set' do
+        before do
+          params.merge!(
+            multicast_address: []
+          )
+        end
+
+        it 'raises error' do
+          is_expected.to raise_error(
+            Puppet::Error,
+            %r{set_votequorum is true, but neither quorum_members were passed nor was multicast specified.}
+          )
+        end
       end
     end
 


### PR DESCRIPTION
#### Pull Request (PR) description

* Nodelist is optional when using multicast, so I made it optional when using multicast.
* Allow `port` to be a single or an array of ports, as mentioned and required by the code.
  The only issue with my fix for `port` is that it seems to require a fairly recent version of the `stdlib`, as `Stdlib::Port` is fairly fresh ([4.25.0](https://github.com/puppetlabs/puppetlabs-stdlib/releases/tag/4.25.0)).

#### This Pull Request (PR) fixes the following issues

n/a