### PR TITLE
Do not explicitly request current environment

### DIFF
--- a/lib/puppet/provider/cs_clone/crm.rb
+++ b/lib/puppet/provider/cs_clone/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_clone/pcs.rb
+++ b/lib/puppet/provider/cs_clone/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_colocation/crm.rb
+++ b/lib/puppet/provider/cs_colocation/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_colocation/pcs.rb
+++ b/lib/puppet/provider/cs_colocation/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_commit/crm.rb
+++ b/lib/puppet/provider/cs_commit/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_commit/pcs.rb
+++ b/lib/puppet/provider/cs_commit/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_group/crm.rb
+++ b/lib/puppet/provider/cs_group/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_group/pcs.rb
+++ b/lib/puppet/provider/cs_group/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_location/crm.rb
+++ b/lib/puppet/provider/cs_location/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_location/pcs.rb
+++ b/lib/puppet/provider/cs_location/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_order/crm.rb
+++ b/lib/puppet/provider/cs_order/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_order/pcs.rb
+++ b/lib/puppet/provider/cs_order/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_property/crm.rb
+++ b/lib/puppet/provider/cs_property/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_property/pcs.rb
+++ b/lib/puppet/provider/cs_property/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_rsc_defaults/crm.rb
+++ b/lib/puppet/provider/cs_rsc_defaults/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_rsc_defaults/pcs.rb
+++ b/lib/puppet/provider/cs_rsc_defaults/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet/provider/cs_shadow/crm.rb
+++ b/lib/puppet/provider/cs_shadow/crm.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/crmsh'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/crmsh'
 end

--- a/lib/puppet/provider/cs_shadow/pcs.rb
+++ b/lib/puppet/provider/cs_shadow/pcs.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/pcs'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/pcs'
 end

--- a/lib/puppet_x/voxpupuli/corosync/provider/cib_helper.rb
+++ b/lib/puppet_x/voxpupuli/corosync/provider/cib_helper.rb
@@ -2,7 +2,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider'
 end

--- a/lib/puppet_x/voxpupuli/corosync/provider/crmsh.rb
+++ b/lib/puppet_x/voxpupuli/corosync/provider/crmsh.rb
@@ -3,7 +3,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/cib_helper'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider'
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/cib_helper'

--- a/lib/puppet_x/voxpupuli/corosync/provider/pcs.rb
+++ b/lib/puppet_x/voxpupuli/corosync/provider/pcs.rb
@@ -3,7 +3,7 @@ begin
   require 'puppet_x/voxpupuli/corosync/provider/cib_helper'
 rescue LoadError
   require 'pathname' # WORKAROUND #14073, #7788 and SERVER-973
-  corosync = Puppet::Module.find('corosync', Puppet[:environment].to_s)
+  corosync = Puppet::Module.find('corosync')
   raise(LoadError, "Unable to find corosync module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless corosync
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider'
   require File.join corosync.path, 'lib/puppet_x/voxpupuli/corosync/provider/cib_helper'


### PR DESCRIPTION
#### Pull Request (PR) description
Do not explicitly request current environment from `Puppet::Module.find`.

This can lead to breakage under certain conditions that aren't fully
clear. Puppet has been using the current environment in `Module.find`
since 1.4.5[1], so it should not be necessary to actually define it.

The unit tests and an integration test for CentOS 7 ran through just fine.

#### This Pull Request (PR) fixes the following issues
Fixes #403 

[1] commit puppetlabs/puppet@b6fc6317573fc2fb94d611bedd3d927ff101d244