### PR TITLE
Use debian9 beaker test with Type=simple corosync override

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -30,6 +30,13 @@ RSpec.configure do |c|
         on host, 'echo deb http://ftp.debian.org/debian jessie-backports main >> /etc/apt/sources.list'
         on host, 'apt-get update && apt-get install -y openhpid', acceptable_exit_codes: [0, 1, 100]
       end
+      # On Debian 9 "stretch", service state transitions (restart, stop) hang indefinitely and
+      # lead to test timeouts if there is a service unit of Type=notify involved.
+      # Use Type=simple as a workaround. See issue 455.
+      if fact('os.family') == 'Debian' && fact('os.release.major') == '9'
+        on host, 'mkdir /etc/systemd/system/corosync.service.d'
+        on host, 'echo -e "[Service]\nType=simple" > /etc/systemd/system/corosync.service.d/10-type-simple.conf'
+      end
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,7 +33,7 @@ RSpec.configure do |c|
       # On Debian 9 "stretch", service state transitions (restart, stop) hang indefinitely and
       # lead to test timeouts if there is a service unit of Type=notify involved.
       # Use Type=simple as a workaround. See issue 455.
-      if fact('os.family') == 'Debian' && fact('os.release.major') == '9'
+      if host[:hypervisor] =~ %r{docker} && fact('os.family') == 'Debian' && fact('os.release.major') == '9'
         on host, 'mkdir /etc/systemd/system/corosync.service.d'
         on host, 'echo -e "[Service]\nType=simple" > /etc/systemd/system/corosync.service.d/10-type-simple.conf'
       end


### PR DESCRIPTION
This is a sample workaround for one of the issues of https://github.com/voxpupuli/puppet-corosync/issues/455. It seems that sd_notify does not work inside the debian9 container which leads to blocking service state transitions.

This pull-requests overrides the corosync service type to simple.