### PR TITLE
Use beaker-docker with Type=simple on rhel/debian

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -30,6 +30,13 @@ RSpec.configure do |c|
         on host, 'echo deb http://ftp.debian.org/debian jessie-backports main >> /etc/apt/sources.list'
         on host, 'apt-get update && apt-get install -y openhpid', acceptable_exit_codes: [0, 1, 100]
       end
+      # On Debian 9 and CentOS 7, service state transitions (restart, stop) hang indefinitely and
+      # lead to test timeouts if there is a service unit of Type=notify is involved.
+      # Use Type=simple as a workaround. See https://github.com/voxpupuli/puppet-corosync/issues/455
+      if host[:hypervisor] =~ %r{docker} && %w[Debian CentOS].include?(fact('os.name'))
+        on host, 'mkdir /etc/systemd/system/corosync.service.d'
+        on host, 'echo -e "[Service]\nType=simple" > /etc/systemd/system/corosync.service.d/10-type-simple.conf'
+      end
     end
   end
 end


### PR DESCRIPTION
This is a an update to https://github.com/voxpupuli/puppet-corosync/pull/456/