### PR TITLE
Add SLES 12/15 Support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,20 @@ class corosync::params {
       $package_install_options = undef
     }
 
+    'Suse': {
+      case $facts['os']['name'] {
+        'SLES': {
+          $package_crmsh  = true
+          $package_pcs    = false
+          $package_fence_agents = false
+          $package_install_options = undef
+        }
+        default: {
+          fail("Unsupported flavour of ${facts['os']['family']}: ${facts['os']['name']}")
+        }
+      }
+    }
+
     default: {
       fail("Unsupported operating system: ${facts['os']['name']}")
     }

--- a/metadata.json
+++ b/metadata.json
@@ -31,6 +31,13 @@
       "operatingsystemrelease": [
         "16.04"
       ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemmajrelease": [
+        "12",
+        "15"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
#### Pull Request (PR) description

Adds support for SUSE Linux Enterprise Server to the puppetlabs-corosync module.
No special care is given to ensure only supported clusters are used, that's for either a profile or a separate module.

#### This Pull Request (PR) fixes the following issues

n/a