### PR TITLE
cs_primitive pcs Master Update Syntax Correction

### DIFF
--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -260,7 +260,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, parent: PuppetX::Voxpupuli::Coros
       cmd += metadatas unless metadatas.nil?
       self.class.run_command_in_cib(cmd, @resource[:cib])
       if @property_hash[:promotable] == :true
-        cmd = [command(:pcs), 'resource', 'update', "ms_#{@property_hash[:name]}", (@property_hash[:name]).to_s]
+        cmd = [command(:pcs), 'resource', 'update', "ms_#{@property_hash[:name]}"]
         unless @property_hash[:ms_metadata].empty? && @property_hash[:existing_ms_metadata].empty?
           cmd << 'meta'
           @property_hash[:ms_metadata].each_pair do |k, v|


### PR DESCRIPTION
#### Pull Request (PR) description

When the cs_primitive provider for PCS attempts to update a primitive with the Master/Slave promotable structure in the release a syntax error is generated. See issue #459 for details. This change corrects that behavior and works as expected on CentOS/RHEL 7.6.

#### This Pull Request (PR) fixes the following issues

Fixes #459 
