### PR TITLE
Don't fail when set_votequorum=true and cluster_name is set

### DIFF
--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -532,7 +532,7 @@ describe 'corosync' do
       end
     end
 
-    context 'when set_quorum is true and quorum_members is not set' do
+    context 'when set_votequorum is true and quorum_members is not set' do
       before do
         params.merge!(
           set_votequorum: true,
@@ -543,7 +543,8 @@ describe 'corosync' do
       context 'when multicast_address is set' do
         before do
           params.merge!(
-            multicast_address: '10.0.0.1'
+            multicast_address: '10.0.0.1',
+            cluster_name: :undef
           )
         end
 
@@ -554,17 +555,33 @@ describe 'corosync' do
         end
       end
 
-      context 'when multicast_address is not set' do
+      context 'when cluster_name is set' do
         before do
           params.merge!(
-            multicast_address: []
+            multicast_address: [],
+            cluster_name: 'mycluster'
+          )
+        end
+
+        it 'does not contain nodelist' do
+          is_expected.not_to contain_file('/etc/corosync/corosync.conf').with_content(
+            %r{nodelist}
+          )
+        end
+      end
+
+      context 'when multicast_address and cluster_name are not set' do
+        before do
+          params.merge!(
+            multicast_address: [],
+            cluster_name: :undef
           )
         end
 
         it 'raises error' do
           is_expected.to raise_error(
             Puppet::Error,
-            %r{set_votequorum is true, but neither quorum_members were passed nor was multicast specified.}
+            %r{set_votequorum is true, so you must set either quorum_members, or one of multicast_address or cluster_name.}
           )
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description

Corosync allows setting cluster_name so the user does not have to manually define and specify multicast addresses (the addresses are derived from the cluster name).

This means that Puppet catalog compilation should not fail() when set_votequorum is true and cluster_name is set but quorum_members and multicast_address are empty. Only fail when neither quorum_members, nor multicast_address nor cluster_name are defined.

This change updates the logic and extends the spec tests to cover the described case.

#### This Pull Request (PR) fixes the following issues

Fixes #472