### PR TITLE
fix: cs_primitive pcs resource update for Master/Slave primitive correction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ for the created virtual machines will be in `.vagrant/beaker_vagrant_fies`.
 If you are using vagrant instead of docker for local testing you will need to
 ensure that the beaker-vagrant is installed.
 
-1. Add `gem "beaker-vagrant,                     :require => false"` to the Gemfile.
+1. Add `gem 'beaker-vagrant',                     :require => false` to the Gemfile.
 1. Re-run `bundle install` to add all relevant packages.
 
 Once this is in-place, you can execute a test on an CentOS 7 VM with puppet5 as follows:

--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -277,7 +277,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, parent: PuppetX::Voxpupuli::Coros
       cmd += metadatas unless metadatas.nil?
       self.class.run_command_in_cib(cmd, @resource[:cib])
       if @property_hash[:promotable] == :true
-        cmd = [command(:pcs), pcs_subcommand, 'update', "ms_#{@property_hash[:name]}", (@property_hash[:name]).to_s]
+        cmd = [command(:pcs), pcs_subcommand, 'update', "ms_#{@property_hash[:name]}"]
         unless @property_hash[:ms_metadata].empty? && @property_hash[:existing_ms_metadata].empty?
           cmd << 'meta'
           @property_hash[:ms_metadata].each_pair do |k, v|


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->
When the cs_primitive provider for PCS attempts to update a primitive with the Master/Slave promotable structure in the release a syntax error is generated. See issue #459 for details. This change corrects that behavior and works as expected on CentOS/RHEL 7.6 as shown by the updated acceptance tests.

Note that this is really a re-opening of #470, however, I couldn't figure out how to reopen that pull request. I inadvertently closed it yesterday thinking the code was included in one of my other pulls

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->

Fixes #459