### PR TITLE
allow auth_node to be declared whith short name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -564,6 +564,7 @@ class corosync(
     # If the local data matches auth_node (hostname or primary IP) we can
     # perform auth processing for subsequent components
     if $trusted['certname'] == $auth_node
+      or $trusted['hostname'] == $auth_node
       or $auth_node == $facts['networking']['ip']
       or $auth_node in $interface_ip_list {
           $is_auth_node = true


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
allow auth_node to be declared with short hostname in corosync::quorum_members

#### This Pull Request (PR) fixes the following issues
NA
