### PR TITLE
Drop unsupported code 1.x support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -27,6 +27,15 @@
 * [`cs_rsc_defaults`](#cs_rsc_defaults): Type for manipulating corosync/pacemaker global defaults for resource options. The type is pretty simple interface for setting key/value pair
 * [`cs_shadow`](#cs_shadow): cs_shadow resources represent a Corosync shadow CIB. Any corosync resources defined with 'cib' set to the title of a cs_shadow resource will 
 
+**Data types**
+
+* [`Corosync::ArrayRing`](#corosyncarrayring): 
+* [`Corosync::CryptoCipher`](#corosynccryptocipher): Defines the allowed cipher types for secure corosync communication
+* [`Corosync::CryptoHash`](#corosynccryptohash): 
+* [`Corosync::IpStringIp`](#corosyncipstringip): 
+* [`Corosync::QuorumAlgorithm`](#corosyncquorumalgorithm): 
+* [`Corosync::Syslogpriority`](#corosyncsyslogpriority): 
+
 ## Classes
 
 ### corosync
@@ -68,16 +77,6 @@ Data type: `Boolean`
 Controls corosync's ability to authenticate and encrypt multicast messages.
 
 Default value: $corosync::params::enable_secauth
-
-##### `secauth_parameter_mode`
-
-Data type: `Enum['1.x','2.x']`
-
-Determines whether the crypto_hash and crypto_cipher parameters are
-specified. These flags were added in Corosync 2.x so operating systems using
-older 1.x packages must continue to use sec_auth instead.
-
-Default value: $corosync::params::secauth_parameter_mode
 
 ##### `authkey_source`
 
@@ -329,7 +328,7 @@ Default value: $corosync::params::package_fence_agents
 
 ##### `packageopts_corosync`
 
-Data type: `Optional[Array]`
+Data type: `Optional[Array[String[1]]]`
 
 Additional install-options for the corosync package resource.
 Default (Debian Jessie):  ['-t', 'jessie-backports']
@@ -339,7 +338,7 @@ Default value: $corosync::params::package_install_options
 
 ##### `packageopts_crmsh`
 
-Data type: `Optional[Array]`
+Data type: `Optional[Array[String[1]]]`
 
 Additional install-options for the crmsh package resource.
 Default (Debian Jessie):  ['-t', 'jessie-backports']
@@ -349,7 +348,7 @@ Default value: $corosync::params::package_install_options
 
 ##### `packageopts_pacemaker`
 
-Data type: `Optional[Array]`
+Data type: `Optional[Array[String[1]]]`
 
 Additional install-options for the pacemaker package resource.
 Default (Debian Jessie):  ['-t', 'jessie-backports']
@@ -359,7 +358,7 @@ Default value: $corosync::params::package_install_options
 
 ##### `packageopts_pcs`
 
-Data type: `Optional[Array]`
+Data type: `Optional[Array[String[1]]]`
 
 Additional install-options for the pcs package resource.
 Default (Debian Jessie):  ['-t', 'jessie-backports']
@@ -369,7 +368,7 @@ Default value: $corosync::params::package_install_options
 
 ##### `packageopts_fence_agents`
 
-Data type: `Optional[Array]`
+Data type: `Optional[Array[String[1]]]`
 
 Additional install-options for the pcs package resource.
 Default (Debian Jessie):  ['-t', 'jessie-backports']
@@ -379,7 +378,7 @@ Default value: $corosync::params::package_install_options
 
 ##### `version_corosync`
 
-Data type: `String`
+Data type: `String[1]`
 
 Define what version of the corosync package should be installed.
 Default: 'present'
@@ -388,7 +387,7 @@ Default value: $corosync::params::version_corosync
 
 ##### `version_crmsh`
 
-Data type: `String`
+Data type: `String[1]`
 
 Define what version of the crmsh package should be installed.
 Default: 'present'
@@ -397,7 +396,7 @@ Default value: $corosync::params::version_crmsh
 
 ##### `version_pacemaker`
 
-Data type: `String`
+Data type: `String[1]`
 
 Define what version of the pacemaker package should be installed.
 Default: 'present'
@@ -406,7 +405,7 @@ Default value: $corosync::params::version_pacemaker
 
 ##### `version_pcs`
 
-Data type: `String`
+Data type: `String[1]`
 
 Define what version of the pcs package should be installed.
 Default: 'present'
@@ -415,7 +414,7 @@ Default value: $corosync::params::version_pcs
 
 ##### `version_fence_agents`
 
-Data type: `String`
+Data type: `String[1]`
 
 Define what version of the fence-agents-all package should be installed.
 Default: 'present'
@@ -649,7 +648,7 @@ Default value: `undef`
 
 ##### `cluster_name`
 
-Data type: `Optional[String]`
+Data type: `Optional[String[1]]`
 
 This specifies the name of cluster and it's used for automatic
 generating of multicast address.
@@ -674,6 +673,21 @@ achieved before starting a new round of membership configuration.
 The minimum value for consensus must be 1.2 * token. This value will be
 automatically calculated at 1.2 * token if the user doesn't specify a
 consensus value.
+
+Default value: `undef`
+
+##### `ip_version`
+
+Data type: `Optional[String[1]]`
+
+This specifies version of IP to ask DNS resolver for.  The value can be
+one of ipv4 (look only for an IPv4 address) , ipv6 (check only IPv6 address),
+ipv4-6 (look for all address families and use first IPv4 address found in the
+list if there is such address, otherwise use first IPv6 address) and
+ipv6-4 (look for all address families and use first IPv6 address found in the
+list if there is such address, otherwise use first IPv4 address).
+
+Default (if unspecified) is ipv6-4 for knet and udpu transports and ipv4 for udp.
 
 Default value: `undef`
 
@@ -708,10 +722,6 @@ Data type: `Boolean`
 
 Whether we should test new configuration files with `corosync -t`.
 (requires corosync 2.3.4)
-Default (Red Hat based >= 7): true
-Default (Ubuntu >= 16.04):    true
-Default (Debian >= 8):        true
-Default (otherwise):          false
 
 Default value: $corosync::params::test_corosync_config
 
@@ -1610,4 +1620,46 @@ Whether to generate a cs_commit or not. Can be used to create shadow
 CIB without committing them.
 
 Default value: `true`
+
+## Data types
+
+### Corosync::ArrayRing
+
+The Corosync::ArrayRing data type.
+
+Alias of `Variant[Array[Stdlib::IP::Address], Array[
+    Array[Stdlib::IP::Address]
+  ]]`
+
+### Corosync::CryptoCipher
+
+Defines the allowed cipher types for secure corosync communication
+
+Alias of `Enum['aes256', 'aes192', 'aes128', '3des']`
+
+### Corosync::CryptoHash
+
+The Corosync::CryptoHash data type.
+
+Alias of `Enum['md5', 'sha1', 'sha256', 'sha384', 'sha512']`
+
+### Corosync::IpStringIp
+
+The Corosync::IpStringIp data type.
+
+Alias of `Variant[Stdlib::IP::Address, Array[
+    Stdlib::IP::Address
+  ]]`
+
+### Corosync::QuorumAlgorithm
+
+The Corosync::QuorumAlgorithm data type.
+
+Alias of `Enum['ffsplit', 'lms']`
+
+### Corosync::Syslogpriority
+
+The Corosync::Syslogpriority data type.
+
+Alias of `Enum['debug', 'info', 'notice', 'warning', 'err', 'alert', 'emerg', 'crit']`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -694,24 +694,19 @@ class corosync(
   # - $max_messages
   if $test_corosync_config {
     # corosync -t is only included since 2.3.4
-    file { '/etc/corosync/corosync.conf':
-      ensure       => file,
-      mode         => '0644',
-      owner        => 'root',
-      group        => 'root',
-      content      => template("${module_name}/corosync.conf.erb"),
-      validate_cmd => '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t',
-      require      => $corosync_package_require,
-    }
+    $config_validate_cmd = '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
   } else {
-    file { '/etc/corosync/corosync.conf':
-      ensure  => file,
-      mode    => '0644',
-      owner   => 'root',
-      group   => 'root',
-      content => template("${module_name}/corosync.conf.erb"),
-      require => $corosync_package_require,
-    }
+    $config_validate_cmd = undef
+  }
+
+  file { '/etc/corosync/corosync.conf':
+    ensure       => file,
+    mode         => '0644',
+    owner        => 'root',
+    group        => 'root',
+    content      => template("${module_name}/corosync.conf.erb"),
+    validate_cmd => $config_validate_cmd,
+    require      => $corosync_package_require,
   }
 
   file { '/etc/corosync/service.d':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,11 +8,6 @@
 # @param enable_secauth
 #   Controls corosync's ability to authenticate and encrypt multicast messages.
 #
-# @param secauth_parameter_mode
-#   Determines whether the crypto_hash and crypto_cipher parameters are
-#   specified. These flags were added in Corosync 2.x so operating systems using
-#   older 1.x packages must continue to use sec_auth instead.
-#
 # @param authkey_source
 #   Allows to use either a file or a string as a authkey.
 #
@@ -324,10 +319,6 @@
 # @param test_corosync_config
 #   Whether we should test new configuration files with `corosync -t`.
 #   (requires corosync 2.3.4)
-#   Default (Red Hat based >= 7): true
-#   Default (Ubuntu >= 16.04):    true
-#   Default (Debian >= 8):        true
-#   Default (otherwise):          false
 #
 # @example Simple configuration without secauth
 #
@@ -347,7 +338,6 @@
 #
 class corosync(
   Boolean $enable_secauth                                            = $corosync::params::enable_secauth,
-  Enum['1.x','2.x'] $secauth_parameter_mode                          = $corosync::params::secauth_parameter_mode,
   Enum['file', 'string'] $authkey_source                             = $corosync::params::authkey_source,
   Variant[Stdlib::Absolutepath,Stdlib::Base64] $authkey              = $corosync::params::authkey,
   Corosync::CryptoHash $crypto_hash                                  = 'sha1',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,22 +25,15 @@ class corosync::params {
   $enable_pacemaker_service            = true
   $enable_pcsd_service                 = true
   $package_quorum_device               = 'corosync-qdevice'
+  $set_votequorum                      = true
+  $manage_pacemaker_service            = true
+  $test_corosync_config                = true
 
   case $::osfamily {
     'RedHat': {
       $package_crmsh  = false
       $package_pcs    = true
       $package_fence_agents = true
-      $set_votequorum = true
-      if versioncmp($::operatingsystemrelease, '7') >= 0 {
-        $manage_pacemaker_service = true
-        $test_corosync_config = true
-        $secauth_parameter_mode = '2.x'
-      } else {
-        $manage_pacemaker_service = false
-        $test_corosync_config = false
-        $secauth_parameter_mode = '1.x'
-      }
       $package_install_options = undef
     }
 
@@ -48,58 +41,17 @@ class corosync::params {
       $package_crmsh  = true
       $package_pcs    = false
       $package_fence_agents = false
+
       case $::operatingsystem {
-        'Ubuntu': {
-          if versioncmp($::operatingsystemrelease, '14.04') >= 0 {
-            $set_votequorum = true
-            $manage_pacemaker_service = true
-            $secauth_parameter_mode = '2.x'
-
-            if versioncmp($::operatingsystemrelease, '16.04') >= 0 {
-              $test_corosync_config = true
-            } else {
-
-              #FIXME should be moved in another place
-              file {'/etc/default/cman':
-                ensure  => present,
-                content => template('corosync/cman.erb'),
-              }
-
-              $test_corosync_config = false
-            }
-          } else {
-            $set_votequorum = false
-            $manage_pacemaker_service = false
-            $test_corosync_config = false
-            $secauth_parameter_mode = '1.x'
-          }
-          $package_install_options = undef
-        }
         'Debian': {
-          if versioncmp($::operatingsystemrelease, '8') >= 0 {
-            $set_votequorum = true
-            $manage_pacemaker_service = true
-            $test_corosync_config = true
-            $secauth_parameter_mode = '2.x'
-            if versioncmp($::operatingsystemrelease, '8') == 0 {
-              $package_install_options = ['-t', 'jessie-backports']
-            } else {
-              $package_install_options = undef
-            }
+          if versioncmp($::operatingsystemrelease, '8') == 0 {
+            $package_install_options = ['-t', 'jessie-backports']
           } else {
-            $set_votequorum = false
-            $manage_pacemaker_service = false
             $package_install_options = undef
-            $test_corosync_config = false
-            $secauth_parameter_mode = '1.x'
           }
         }
         default : {
-          $set_votequorum = false
-          $manage_pacemaker_service = false
           $package_install_options = undef
-          $test_corosync_config = false
-          $secauth_parameter_mode = '1.x'
         }
       }
     }

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -15,6 +15,12 @@ describe 'corosync' do
       )
     end
 
+    it 'validates the corosync configuration' do
+      is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
+        '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
+      )
+    end
+
     context 'when manage_corosync_service is false' do
       before do
         params.merge!(
@@ -613,12 +619,6 @@ describe 'corosync' do
       }
     end
 
-    it 'validates the corosync configuration' do
-      is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
-        '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
-      )
-    end
-
     context 'without secauth' do
       before do
         params.merge!(
@@ -665,62 +665,6 @@ describe 'corosync' do
       { osfamily:       'RedHat',
         processorcount: '3',
         ipaddress:      '127.0.0.1' }
-    end
-
-    context 'major version is 6' do
-      before do
-        facts.merge!(operatingsystemrelease: '6.12')
-      end
-
-      it_configures 'corosync'
-
-      context 'installs default packages' do
-        ['pcs', 'fence-agents-all'].each do |package|
-          it "installs #{package}" do
-            is_expected.to contain_package(package)
-          end
-        end
-      end
-
-      context 'without secauth' do
-        before do
-          params.merge!(
-            enable_secauth: false
-          )
-        end
-
-        it { is_expected.to compile.with_all_deps }
-
-        it 'disables secauth with corsync 1.x syntax' do
-          is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
-            %r{secauth:\s+off}
-          )
-        end
-      end
-
-      context 'with secauth' do
-        before do
-          params.merge!(
-            enable_secauth: true
-          )
-        end
-
-        it { is_expected.to compile.with_all_deps }
-
-        it 'enables secauth with corsync 1.x syntax' do
-          is_expected.to contain_file('/etc/corosync/corosync.conf').with_content(
-            %r{secauth:\s+on}
-          )
-        end
-      end
-
-      it 'does not manage the pacemaker service' do
-        is_expected.not_to contain_service('pacemaker')
-      end
-
-      it 'does not validate the corosync configuration' do
-        is_expected.to contain_file('/etc/corosync/corosync.conf').without_validate_cmd
-      end
     end
 
     context 'major version is 7' do
@@ -780,12 +724,6 @@ describe 'corosync' do
             %r{crypto_cipher:\s+aes256}
           )
         end
-      end
-
-      it 'validates the corosync configuration' do
-        is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
-          '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
-        )
       end
 
       it 'installs the pcs package' do

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -40,17 +40,12 @@ totem {
 <% if @netmtu -%>
   netmtu:                              <%= @netmtu %>
 <% end -%>
-<% case @secauth_parameter_mode
-   when '1.x' -%>
-  secauth:                             <%= @enable_secauth ? 'on' : 'off' %>
-<% when '2.x' -%>
 <% if @enable_secauth -%>
   crypto_hash:                         <%= @crypto_hash %>
   crypto_cipher:                       <%= @crypto_cipher %>
 <% else -%>
   crypto_hash:                         none
   crypto_cipher:                       none
-<% end -%>
 <% end -%>
 <% if @threads -%>
   threads:                             <%= @threads %>


### PR DESCRIPTION
According to metadata.json these are all unsupported. This cleans up support for 1.x.