### PR TITLE
issue #485: remove score parameter from cs_order

### DIFF
--- a/lib/puppet/provider/cs_order/crm.rb
+++ b/lib/puppet/provider/cs_order/crm.rb
@@ -54,7 +54,6 @@ Puppet::Type.type(:cs_order).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
         ensure:      :present,
         first:       first,
         second:      second,
-        score:       items['score'],
         symmetrical: symmetrical,
         provider:    name
       }
@@ -71,7 +70,6 @@ Puppet::Type.type(:cs_order).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
       ensure:      :present,
       first:       @resource[:first],
       second:      @resource[:second],
-      score:       @resource[:score],
       symmetrical: @resource[:symmetrical],
       kind:        @resource[:kind],
       cib:         @resource[:cib]
@@ -93,7 +91,7 @@ Puppet::Type.type(:cs_order).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
     return if @property_hash.empty?
 
     updated = 'order '
-    updated << "#{@property_hash[:name]} #{@property_hash[:score]}: "
+    updated << "#{@property_hash[:name]} "
     updated << "#{@property_hash[:first]} #{@property_hash[:second]} symmetrical=#{@property_hash[:symmetrical]}"
     updated << " kind=#{@property_hash[:kind]}" if feature? :kindness
     debug("Loading update: #{updated}")

--- a/lib/puppet/provider/cs_order/pcs.rb
+++ b/lib/puppet/provider/cs_order/pcs.rb
@@ -47,11 +47,6 @@ Puppet::Type.type(:cs_order).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync:
                  else
                    items['then']
                  end
-        score = if items['score']
-                  items['score']
-                else
-                  'INFINITY'
-                end
         kind = if items['kind']
                  items['kind']
                else
@@ -70,7 +65,6 @@ Puppet::Type.type(:cs_order).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync:
           ensure:      :present,
           first:       first,
           second:      second,
-          score:       score,
           kind:        kind,
           symmetrical: symmetrical,
           provider:    name,
@@ -90,7 +84,6 @@ Puppet::Type.type(:cs_order).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync:
       ensure:      :present,
       first:       @resource[:first],
       second:      @resource[:second],
-      score:       @resource[:score],
       kind:        @resource[:kind],
       symmetrical: @resource[:symmetrical],
       new:         true
@@ -126,7 +119,6 @@ Puppet::Type.type(:cs_order).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync:
     items = @property_hash[:second].split(':')
     cmd << items[1]
     cmd << items[0]
-    cmd << @property_hash[:score]
     cmd << "kind=#{@property_hash[:kind]}"
     cmd << "id=#{@property_hash[:name]}"
     cmd << "symmetrical=#{@property_hash[:symmetrical]}"

--- a/lib/puppet/type/cs_order.rb
+++ b/lib/puppet/type/cs_order.rb
@@ -54,16 +54,6 @@ Puppet::Type.newtype(:cs_order) do
       also be added to your manifest."
   end
 
-  newproperty(:score) do
-    desc "The priority of the this ordered grouping.  Primitives can be a part
-      of multiple order groups and so there is a way to control which
-      primitives get priority when forcing the order of state changes on
-      other primitives.  This value can be an integer but is often defined
-      as the string INFINITY."
-
-    defaultto 'INFINITY'
-  end
-
   newproperty(:kind, required_features: :kindness) do
     desc "How to enforce the constraint.
 


### PR DESCRIPTION
I didn't spot an open PR on this, but there is open issue #485 

It seems that the release of pacemaker 2.0.3 (in RHEL8) removes the option of supplying the superfluous score parameter.

#### Pull Request (PR) description
Removes the score parameter from cs_order type as it is no longer valid and causes errors.

#### This Pull Request (PR) fixes the following issues
Fixes #485
