### PR TITLE
bug with ubuntu 20.04 (corosync v3) and secauth is enabled (crypto_cipher and crypto_hash are valid only for Knet transport)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -292,10 +292,10 @@
 #   consensus value.
 #
 # @param ip_version
-#   This specifies version of IP to ask DNS resolver for.  The value can be 
+#   This specifies version of IP to ask DNS resolver for.  The value can be
 #   one of ipv4 (look only for an IPv4 address) , ipv6 (check only IPv6 address),
 #   ipv4-6 (look for all address families and use first IPv4 address found in the
-#   list if there is such address, otherwise use first IPv6 address) and 
+#   list if there is such address, otherwise use first IPv6 address) and
 #   ipv6-4 (look for all address families and use first IPv6 address found in the
 #   list if there is such address, otherwise use first IPv4 address).
 #
@@ -319,6 +319,12 @@
 # @param test_corosync_config
 #   Whether we should test new configuration files with `corosync -t`.
 #   (requires corosync 2.3.4)
+#
+# @param major_version_corosync
+#  Can be equal to '1' or '2' or '3'. By default, it is determined automatically depending
+#  on the os distribution or the specified version in version_corosync parameter.
+#  Configuration files may differ depending on the major version.
+#
 #
 # @example Simple configuration without secauth
 #
@@ -405,6 +411,7 @@ class corosync (
   Optional[Enum['yes', 'no']] $clear_node_high_bit                   = undef,
   Optional[Integer] $max_messages                                    = undef,
   Boolean $test_corosync_config                                      = $corosync::params::test_corosync_config,
+  Enum['3', '2', '1'] $major_version_corosync                        = $corosync::params::major_version_corosync
 ) inherits corosync::params {
   if $set_votequorum and (empty($quorum_members) and empty($multicast_address) and !$cluster_name) {
     fail('set_votequorum is true, so you must set either quorum_members, or one of multicast_address or cluster_name.')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,6 +35,7 @@ class corosync::params {
       $package_pcs    = true
       $package_fence_agents = true
       $package_install_options = undef
+      $major_version_corosync_detect_by_distr = '2'
     }
 
     'Debian': {
@@ -44,20 +45,56 @@ class corosync::params {
 
       case $facts['os']['name'] {
         'Debian': {
+          if versioncmp($facts['os']['release']['full'], '9') == 0 {
+            $package_install_options = undef
+            $major_version_corosync_detect_by_distr = '2'
+          }
+
+          if versioncmp($facts['os']['release']['full'], '10') >= 0 {
+            $package_install_options = undef
+            $major_version_corosync_detect_by_distr = '3'
+          }
+
           if versioncmp($facts['os']['release']['full'], '8') == 0 {
             $package_install_options = ['-t', 'jessie-backports']
+            $major_version_corosync_detect_by_distr = '1'
           } else {
             $package_install_options = undef
+            $major_version_corosync_detect_by_distr = '2'
+          }
+        }
+        'Ubuntu': {
+          $package_install_options = undef
+          if versioncmp($facts['os']['release']['full'], '19.10') >= 0 {
+            $major_version_corosync_detect_by_distr = '3'
+          } else {
+            $major_version_corosync_detect_by_distr = '2'
           }
         }
         default : {
           $package_install_options = undef
+          $major_version_corosync_detect_by_distr = '2'
         }
       }
     }
 
     default: {
       fail("Unsupported operating system: ${facts['os']['name']}")
+    }
+  }
+
+  case $version_corosync {
+    /^1.*/: {
+      $major_version_corosync = '1'
+    }
+    /^2.*/: {
+      $major_version_corosync = '2'
+    }
+    /^3.*/: {
+      $major_version_corosync = '3'
+    }
+    default: {
+      $major_version_corosync = $major_version_corosync_detect_by_distr
     }
   }
 }

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -51,7 +51,11 @@ totem {
   threads:                             <%= @threads %>
 <% end -%>
 <% if @unicast_addresses -%>
+  <%- if @enable_secauth and @major_version_corosync == '3' -%>
+  knet_transport:                      udp
+  <%- else -%>
   transport:                           udpu
+  <%- end -%>
 <% Array(@unicast_addresses.first).each_index do |interface| -%>
   interface {
 <% if not @set_votequorum -%>


### PR DESCRIPTION
Fixed a bug, for ubuntu 20.04 (corosync v3), with the secauth parameter enabled, we get a configuration error: "parsing error in the configuration: crypto_cipher and crypto_hash are valid only for Knet transport"

### Affected Puppet, Ruby, OS and module versions/distributions
```
puppetserver: 5.3.7
puppet agent: 5.5.17
Distribution: Ubuntu 20.04 (focal)
this module: 7.0.0
```

### How to reproduce (e.g Puppet code you use)
```puppet
    class { 'corosync':
        cluster_name       => 'name',
        unicast_addresses  => ['192.168.1.2', '192.168.1.3', '192.168.1.3'],
        set_votequorum     => true,
        quorum_members     => ['192.168.1.2', '192.168.1.3', '192.168.1.3'],
        enable_secauth     => true,
        authkey            => "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
    }
```

I am getting this error when starting the service:
```
Nov 26 14:36:38 lb18-1 systemd[1]: Starting Corosync Cluster Engine...
Nov 26 14:36:38 lb18-1 corosync[47175]:   [MAIN  ] Corosync Cluster Engine 3.0.3 starting up
Nov 26 14:36:38 lb18-1 corosync[47175]:   [MAIN  ] Corosync built-in features: dbus monitoring watchdog augeas systemd xmlconf vqsim nozzle snmp pie relro bi>
Nov 26 14:36:38 lb18-1 corosync[47175]:   [MAIN  ] parse error in config: crypto_cipher & crypto_hash are only valid for the Knet transport.
Nov 26 14:36:38 lb18-1 corosync[47175]:   [MAIN  ] Corosync Cluster Engine exiting with status 8 at main.c:1386.
Nov 26 14:36:38 lb18-1 systemd[1]: corosync.service: Main process exited, code=exited, status=8/n/a
Nov 26 14:36:38 lb18-1 systemd[1]: corosync.service: Failed with result 'exit-code'.
```
Error: `parse error in config: crypto_cipher & crypto_hash are only valid for the Knet transport.`

In the third version of corosync, the parameters crypto_hash and crypto_cipher cannot be used with the transport parameter:
```
       crypto_hash
              This  specifies which HMAC authentication should be used to authenticate all messages. Valid values are none (no authentication), md5, sha1,
              sha256, sha384 and sha512. Encrypted transmission is only supported for the knet transport.

              The default is none.

       crypto_cipher
              This specifies which cipher should be used to encrypt all messages.  Valid values are none (no encryption), aes256, aes192 and aes128.   En‐
              abling crypto_cipher, requires also enabling of crypto_hash. Encrypted transmission is only supported for the knet transport.

              The default is none.

       secauth
              This  implies crypto_cipher=aes256 and crypto_hash=sha256, unless those options are explicitly set. Encrypted transmission is only supported
              for the knet transport.
```

I fixed this, for version 3 corosync is now using knet_transport  (Ubuntu >=19.10 and Debian >=10)

