### PR TITLE
Match user creation in qdevice to the one in init, solves #494

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -596,7 +596,8 @@ class corosync (
 
     if $manage_quorum_device and $manage_pcsd_auth and $set_votequorum {
       package { $package_quorum_device:
-        ensure => 'present',
+        ensure          => 'present',
+        install_options => $packageopts_corosync,
       }
       service { 'corosync-qdevice':
         ensure    => running,

--- a/manifests/qdevice.pp
+++ b/manifests/qdevice.pp
@@ -51,9 +51,9 @@
 #
 # @see https://www.systutorials.com/docs/linux/man/8-corosync-qnetd/
 class corosync::qdevice (
-  String[1] $package_pcs                      = 'pcs',
-  String[1] $package_corosync_qnetd           = 'corosync-qnetd',
-  Sensitive[String] $sensitive_hacluster_hash = undef,
+  String[1] $package_pcs                                = 'pcs',
+  String[1] $package_corosync_qnetd                     = 'corosync-qnetd',
+  Optional[Sensitive[String]] $sensitive_hacluster_hash = undef,
 ) {
   $cluster_group = 'haclient'
   $cluster_user = 'hacluster'

--- a/manifests/qdevice.pp
+++ b/manifests/qdevice.pp
@@ -62,7 +62,6 @@ class corosync::qdevice (
   [$package_pcs, $package_corosync_qnetd].each |$package| {
     package { $package:
       ensure => present,
-      before => Group[$cluster_group],
     }
   }
 
@@ -70,6 +69,7 @@ class corosync::qdevice (
     # Cluster control group
     group { $cluster_group:
       ensure  => 'present',
+      require => Package[$package_pcs, $package_corosync_qnetd],
     }
 
     # Cluster admin credentials

--- a/manifests/qdevice.pp
+++ b/manifests/qdevice.pp
@@ -5,8 +5,9 @@
 # the included example.
 #
 # @param sensitive_hacluster_hash
-#   The password hash for the hacluster user on this quorum device node. This
-#   is currently a mandatory parameter because pcsd must be used to perform the
+#   The password hash for the hacluster user on this quorum device node. If
+#   omitted, you must create the hacluster user and haclient group yourself.
+#   This user is required  because pcsd must be used to perform the
 #   quorum node configuration.
 #
 # @param package_pcs
@@ -65,16 +66,18 @@ class corosync::qdevice (
     }
   }
 
-  # Cluster control group
-  group { $cluster_group:
-    ensure  => 'present',
-  }
+  if $sensitive_hacluster_hash {
+    # Cluster control group
+    group { $cluster_group:
+      ensure  => 'present',
+    }
 
-  # Cluster admin credentials
-  user { $cluster_user:
-    ensure   => 'present',
-    password => $sensitive_hacluster_hash.unwrap,
-    gid      => $cluster_group,
+    # Cluster admin credentials
+    user { $cluster_user:
+      ensure   => 'present',
+      password => $sensitive_hacluster_hash.unwrap,
+      gid      => $cluster_group,
+    }
   }
 
   # Enable the PCS service

--- a/spec/classes/corosync_qdevice_spec.rb
+++ b/spec/classes/corosync_qdevice_spec.rb
@@ -8,7 +8,6 @@ describe 'corosync::qdevice' do
   end
 
   context 'standard quorum node install' do
-    sensitive_value_redacted_message = '#<Sensitive [value redacted]>'
     ['pcs', 'corosync-qnetd'].each do |package|
       it "does install #{package}" do
         is_expected.to contain_package(package).with(
@@ -18,19 +17,13 @@ describe 'corosync::qdevice' do
     end
 
     it 'creates the cluster group' do
-      is_expected.to contain_group('haclient').with(
-        ensure: 'present',
-        require: [
-          'Package[pcs]',
-          'Package[corosync-qnetd]'
-        ]
-      )
+      is_expected.to contain_group('haclient').that_requires('Package[pcs]')
     end
 
     it 'sets the hacluster password' do
       is_expected.to contain_user('hacluster').with(
         ensure: 'present',
-        password: sensitive_value_redacted_message,
+        password: 'some-secret-hash',
         gid: 'haclient'
       )
     end

--- a/spec/classes/corosync_qdevice_spec.rb
+++ b/spec/classes/corosync_qdevice_spec.rb
@@ -11,15 +11,18 @@ describe 'corosync::qdevice' do
     ['pcs', 'corosync-qnetd'].each do |package|
       it "does install #{package}" do
         is_expected.to contain_package(package).with(
-          ensure: 'present',
-          before: 'Group[haclient]'
+          ensure: 'present'
         )
       end
     end
 
     it 'creates the cluster group' do
       is_expected.to contain_group('haclient').with(
-        ensure: 'present'
+        ensure: 'present',
+        require: [
+          'Package[pcs]',
+          'Package[corosync-qnetd]'
+        ]
       )
     end
 

--- a/spec/classes/corosync_qdevice_spec.rb
+++ b/spec/classes/corosync_qdevice_spec.rb
@@ -30,7 +30,7 @@ describe 'corosync::qdevice' do
     it 'sets the hacluster password' do
       is_expected.to contain_user('hacluster').with(
         ensure: 'present',
-        password: /#{Regexp.escape(sensitive_value_redacted_message)}/,
+        password: sensitive_value_redacted_message,
         gid: 'haclient'
       )
     end

--- a/spec/classes/corosync_qdevice_spec.rb
+++ b/spec/classes/corosync_qdevice_spec.rb
@@ -8,6 +8,7 @@ describe 'corosync::qdevice' do
   end
 
   context 'standard quorum node install' do
+    sensitive_value_redacted_message = '#<Sensitive [value redacted]>'
     ['pcs', 'corosync-qnetd'].each do |package|
       it "does install #{package}" do
         is_expected.to contain_package(package).with(
@@ -29,7 +30,7 @@ describe 'corosync::qdevice' do
     it 'sets the hacluster password' do
       is_expected.to contain_user('hacluster').with(
         ensure: 'present',
-        password: 'some-secret-hash',
+        password: /#{Regexp.escape(sensitive_value_redacted_message)}/,
         gid: 'haclient'
       )
     end


### PR DESCRIPTION
#### Pull Request (PR) description
In init.pp, user creation can be skipped by not providing sensitive_hacluster_hash. This change allows to use the same mechanism, when you need to manage the user/group by yourself.

#### This Pull Request (PR) fixes the following issues
Fixes #494
