### PR TITLE
add single-quotes to hacluster_password to properly deal with special…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -577,7 +577,7 @@ class corosync (
     if $manage_pcsd_auth and $is_auth_node {
       # TODO - verify if this breaks out of the sensitivity
       $hacluster_password = $sensitive_hacluster_password.unwrap
-      $auth_credential_string = "-u hacluster -p ${hacluster_password}"
+      $auth_credential_string = "-u hacluster -p \'${hacluster_password}\'"
 
       # As the auth can happen before corosync.conf exists we need to explicitly
       # list the members to join.


### PR DESCRIPTION
… characters

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
This PR adds quotes around the hacluster password so that special characters work in the password.
-->

#### This Pull Request (PR) fixes the following issues
<!--
this PR does not fix an open issue.
-->
