### PR TITLE
expose the config_validate_cmd

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -688,14 +688,9 @@ class corosync (
   # - $clear_node_high_bit
   # - $max_messages
   if $test_corosync_config {
-    if $test_corosync_config_cmd {
-      $config_validate_cmd = $test_corosync_config_cmd
-    } else {
-      # corosync -t is only included since 2.3.4
-      $config_validate_cmd = '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
-    }
+    $_config_validate_cmd = $config_validate_cmd
   } else {
-    $config_validate_cmd = undef
+    $_config_validate_cmd = undef
   }
 
   file { '/etc/corosync/corosync.conf':
@@ -704,7 +699,7 @@ class corosync (
     owner        => 'root',
     group        => 'root',
     content      => template("${module_name}/corosync.conf.erb"),
-    validate_cmd => $config_validate_cmd,
+    validate_cmd => $_config_validate_cmd,
     require      => $corosync_package_require,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -407,7 +407,7 @@ class corosync (
   Optional[String[1]] $ip_version                                       = undef,
   Optional[Enum['yes', 'no']] $clear_node_high_bit                      = undef,
   Optional[Integer] $max_messages                                       = undef,
-  Optional[String] $test_corosync_config_cmd                            = undef,
+  String[1] $config_validate_cmd                                        = '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t',
   Boolean $test_corosync_config                                         = $corosync::params::test_corosync_config,
   Optional[Variant[Stdlib::Absolutepath, Enum['off']]] $watchdog_device = undef,
 ) inherits corosync::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -316,6 +316,9 @@
 #   Whether we should test new configuration files with `corosync -t`.
 #   (requires corosync 2.3.4)
 #
+# @param test_corosync_config_cmd
+#   Override the standard config_validate_cmd which only works for corosync 2.x.
+#
 # @param watchdog_device
 #   Watchdog device to use, for example '/dev/watchdog' or 'off'.
 #   Its presence (or lack thereof) shifted with corosync versions.
@@ -404,6 +407,7 @@ class corosync (
   Optional[String[1]] $ip_version                                       = undef,
   Optional[Enum['yes', 'no']] $clear_node_high_bit                      = undef,
   Optional[Integer] $max_messages                                       = undef,
+  Optional[String] $test_corosync_config_cmd                            = undef,
   Boolean $test_corosync_config                                         = $corosync::params::test_corosync_config,
   Optional[Variant[Stdlib::Absolutepath, Enum['off']]] $watchdog_device = undef,
 ) inherits corosync::params {
@@ -684,8 +688,12 @@ class corosync (
   # - $clear_node_high_bit
   # - $max_messages
   if $test_corosync_config {
-    # corosync -t is only included since 2.3.4
-    $config_validate_cmd = '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
+    if $test_corosync_config_cmd {
+      $config_validate_cmd = $test_corosync_config_cmd
+    } else {
+      # corosync -t is only included since 2.3.4
+      $config_validate_cmd = '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
+    }
   } else {
     $config_validate_cmd = undef
   }

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -20,7 +20,7 @@ describe 'corosync' do
         '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
       )
     end
-    
+
     context 'validates the corosncy configuration when test_corosync_config_cmd is set' do
       let (:params) do
         super().merge(
@@ -33,6 +33,7 @@ describe 'corosync' do
           '/usr/sbin/corosync -t -c %'
         )
       end
+    end
 
     context 'when manage_corosync_service is false' do
       let(:params) do

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -22,8 +22,10 @@ describe 'corosync' do
     end
 
     context 'validates the corosncy configuration when test_corosync_config_cmd is set' do
-      let :params do
-        { test_corosync_config_cmd: '/usr/sbin/corosync -t -c' }
+      let(:params) do
+        super().merge(
+          test_corosync_config_cmd: '/usr/sbin/corosync -t -c'
+        )
       end
 
       it 'validates with test_corosync_config_cmd' do

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -24,13 +24,13 @@ describe 'corosync' do
     context 'validates the corosncy configuration when test_corosync_config_cmd is set' do
       let (:params) do
         super().merge(
-          test_corosync_config_cmd = '/usr/sbin/corosync -t -c %'
+          test_corosync_config_cmd = '/usr/sbin/corosync -t -c'
         )
       end
 
       it 'validates with test_corosync_config_cmd' do
         is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
-          '/usr/sbin/corosync -t -c %'
+          '/usr/sbin/corosync -t -c'
         )
       end
     end

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -20,6 +20,19 @@ describe 'corosync' do
         '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
       )
     end
+    
+    context 'validates the corosncy configuration when test_corosync_config_cmd is set' do
+      let (:params) do
+        super().merge(
+          test_corosync_config_cmd = '/usr/sbin/corosync -t -c %'
+        )
+      end
+
+      it 'validates with test_corosync_config_cmd' do
+        is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
+          '/usr/sbin/corosync -t -c %'
+        )
+      end
 
     context 'when manage_corosync_service is false' do
       let(:params) do

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -21,10 +21,10 @@ describe 'corosync' do
       )
     end
 
-    context 'validates the corosncy configuration when test_corosync_config_cmd is set' do
+    context 'validates the corosncy configuration when config_validate_cmd is set' do
       let(:params) do
         super().merge(
-          test_corosync_config_cmd: '/usr/sbin/corosync -t -c'
+          config_validate_cmd: '/usr/sbin/corosync -t -c'
         )
       end
 

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -22,10 +22,8 @@ describe 'corosync' do
     end
 
     context 'validates the corosncy configuration when test_corosync_config_cmd is set' do
-      let (:params) do
-        super().merge(
-          test_corosync_config_cmd = '/usr/sbin/corosync -t -c'
-        )
+      let :params do
+        { test_corosync_config_cmd: '/usr/sbin/corosync -t -c' }
       end
 
       it 'validates with test_corosync_config_cmd' do


### PR DESCRIPTION
#### Pull Request (PR) description
Corosync 3.x needs another check-cmd (/usr/sbin/corosync -t -c %). To be able to feed this to the module, a parameter needs to be exposed in the modules signature.

#### This Pull Request (PR) fixes the following issues
Fixe #508 
