### PR TITLE
fix parameter description

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -312,9 +312,10 @@
 #   one processor on receipt of the token. The max_messages parameter is limited
 #   to 256000 / netmtu to prevent overflow of the kernel transmit buffers.
 #
-# @param test_corosync_config
-#   Whether we should test new configuration files with `corosync -t`.
-#   (requires corosync 2.3.4)
+# @param config_validate_cmd
+#   Override the default check-command:
+#     Default for Corosync 2.x: '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
+#     Override example for 3.x: '/usr/sbin/corosync -t -c %'
 #
 # @param test_corosync_config_cmd
 #   Override the standard config_validate_cmd which only works for corosync 2.x.


### PR DESCRIPTION

#### Pull Request (PR) description
This comment corrects the description for the newly introduced parameter  param config_validate_cmd which was introduced with #508 

#### This Pull Request (PR) fixes the following issues
Fixes a incorrect descrption of the parameter
