### PR TITLE
Turnoffcrypto

### DIFF
--- a/types/cryptocipher.pp
+++ b/types/cryptocipher.pp
@@ -4,4 +4,5 @@ type Corosync::CryptoCipher = Enum[
   'aes192',
   'aes128',
   '3des',
+  'none',
 ]

--- a/types/cryptohash.pp
+++ b/types/cryptohash.pp
@@ -4,4 +4,5 @@ type Corosync::CryptoHash = Enum[
   'sha256',
   'sha384',
   'sha512',
+  'none',
 ]


### PR DESCRIPTION
It is not possible to use transport: udpu and "cryptohash: none" or "cryptocipher: none" as it is not available as a parameter. I added it. UDPU doesnt support encryption and you are forced to use cryptohash or cryptocipher in corosync.conf (Version 3.x)