### PR TITLE
Converge quorum member auth

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -597,12 +597,18 @@ class corosync (
         default => 'pcs host auth',
       }
 
+      # Check that all nodes have an authorization token
+      $auth_check_command = $quorum_members.map |$node| {
+        "grep '${node}' /var/lib/pcsd/tokens"
+      }.join(' && ')
+
       # Attempt to authorize all members. The command will return successfully
       # if they were already authenticated so it's safe to run every time this
       # is applied.
       # TODO - make it run only once
       exec { 'authorize_members':
         command => "${pcs_auth_command} ${node_string} ${auth_credential_string}",
+        unless  => $auth_check_command,
         path    => $exec_path,
         require => [
           Service['pcsd'],

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -807,6 +807,7 @@ describe 'corosync' do
             it 'authorizes all nodes' do
               is_expected.to contain_exec('authorize_members').with(
                 command: "pcs #{auth_command} node1.test.org node2.test.org node3.test.org -u hacluster -p some-secret-sauce",
+                unless: "grep 'node1.test.org' /var/lib/pcsd/tokens && grep 'node2.test.org' /var/lib/pcsd/tokens && grep 'node3.test.org' /var/lib/pcsd/tokens",
                 path: '/sbin:/bin:/usr/sbin:/usr/bin',
                 require: [
                   'Service[pcsd]',


### PR DESCRIPTION
#### Pull Request (PR) description

The current code for authenticating to quorum members runs the auth command on every puppet run. This both updates the credentials on disk, and generates a puppet change event, which are btoh undesirable.

The proposed change checks to ensure all quorum members have an auth token in the credentials file, and updates auth for all members if any one member is missing. This results in a convergent state.

There is a caveat, in that what gets stored in the credentials file is not the original password, but an auth token. There does not seem to be a pcs command to check the tokens are still valid. So this code is only checking for presenence of auth tokens, not correctness. If the authentication token is later invalided, puppet will not correct this. It would be necessary to manually run the `pcs host auth` or `pcs cluster auth` commands to fix it.

#### This Pull Request (PR) fixes the following issues

Fixes #500