### PR TITLE
Add EL8 support and claim compatibility

### DIFF
--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -1,0 +1,3 @@
+---
+corosync::config_validate_cmd: "/usr/sbin/corosync -c % -t"
+

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -15,12 +15,6 @@ describe 'corosync' do
       )
     end
 
-    it 'validates the corosync configuration' do
-      is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
-        '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
-      )
-    end
-
     context 'validates the corosncy configuration when config_validate_cmd is set' do
       let(:params) do
         super().merge(
@@ -724,6 +718,27 @@ describe 'corosync' do
       end
 
       it_configures 'corosync'
+
+      # Check the correct validation command is used for each OS
+      it 'validates the corosync configuration' do
+        case os_facts[:os]['family']
+        when 'RedHat'
+          case os_facts[:os]['release']['major']
+          when '8'
+            is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
+              '/usr/sbin/corosync -c % -t'
+            )
+          else
+            is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
+              '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
+            )
+          end
+        else
+          is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
+            '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
+          )
+        end
+      end
 
       # Check default package installations per platform
       case os_facts[:os]['family']


### PR DESCRIPTION
#### Pull Request (PR) description

Rework of #484 against latest master branch.

The version of corosync uses a cli parameter instead of an environment variable to point at the config file to be tested. Without this change, the env var is ignored and the `config_validate_cmd` command always checks the real config file location before installing the candidate file. On a new build, this will fail because the real config file does not yet exist. When being updated, the real config file is checked, instead of the candidate file, so an invalid change might be falsely reported as acceptable and lead to an outage.

This change overrides the config validate command on el8 to use the correct syntax.

It also lists el8 as a compatible OS in the module metadata, since the module is currently being used with this patch in production.

#### This Pull Request (PR) fixes the following issues

Fixes #526 
Obsoletes #484 