### PR TITLE
Drop Debian 9 support

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,3 +1,0 @@
----
-corosync::provider: 'pcs'
-corosync::pcs_version: '0.10.0'

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10",
         "11"
       ]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,31 +23,3 @@ end
 require 'spec_helper_corosync'
 
 require 'spec_helper_methods'
-
-# add_custom_fact :corosync_stack, lambda { |os, facts|
-#  case facts[:os]['family']
-#  when 'RedHat'
-#    'pcs'
-#  when 'Debian'
-#    case facts[:os]['name']
-#    when 'Debian'
-#      if facts[:os]['release']['major'].to_i > 9
-#        'pcs'
-#      else
-#        'crm'
-#      end
-#    when 'Ubuntu'
-#      if facts[:os]['release']['major'].to_i > 18
-#        'pcs'
-#      elsif facts[:os]['release']['major'].to_i > 16
-#        'pcs'
-#      else
-#        'crm'
-#      end
-#    end
-#  when 'Suse'
-#    'crm'
-#  else
-#    'crm'
-#  end
-# }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -12,13 +12,8 @@ configure_beaker do |host|
   when 'Debian'
     case fact_on(host, 'os.name')
     when 'Debian'
-      if fact_on(host, 'os.release.major').to_i > 9
-        default_provider = 'pcs'
-        pcs_version = '0.10.0'
-      else
-        default_provider = 'crm'
-        pcs_version = ''
-      end
+      default_provider = 'pcs'
+      pcs_version = '0.10.0'
     when 'Ubuntu'
       if fact_on(host, 'os.release.major').to_i > 18
         default_provider = 'pcs'

--- a/spec/spec_helper_corosync.rb
+++ b/spec/spec_helper_corosync.rb
@@ -12,13 +12,8 @@ def corosync_stack(facts)
   when 'Debian'
     case facts[:os]['name']
     when 'Debian'
-      if facts[:os]['release']['major'].to_i > 9
-        corosync_stack = 'pcs'
-        pcs_version = '0.10.0'
-      else
-        corosync_stack = 'crm'
-        pcs_version = ''
-      end
+      corosync_stack = 'pcs'
+      pcs_version = '0.10.0'
     when 'Ubuntu'
       if facts[:os]['release']['major'].to_i > 18
         corosync_stack = 'pcs'


### PR DESCRIPTION
Debian 9 is EoL, we only support Debian 10 and 11.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
