### PR TITLE
BERG-4121: Backported use of Binary() which should be supported since…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -387,7 +387,7 @@ class corosync(
       'string': {
         file { '/etc/corosync/authkey':
           ensure  => file,
-          content => $authkey,
+          content => Binary($authkey, '%B'),
           mode    => '0400',
           owner   => 'root',
           group   => 'root',


### PR DESCRIPTION
… Puppet 4.x but fails in my IDE. Let's see...

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
