### PR TITLE
Make promotable resources configurable with cs_clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,21 @@ cs_clone { 'nginx_service-clone' :
 }
 ```
 
+Configure a Promotable (Active/Passive) resource
+
+```puppet
+cs_clone { 'redis-clone':
+  ensure            => present,
+  primitive         => 'redis',
+  clone_max         => 2,
+  clone_node_max    => 1,
+  promotable        => true,
+  promoted_max      => 1,
+  promoted_node_max => 1,
+  notify_clones     => true,
+}
+```
+
 ### Corosync Properties
 
 A few global settings can be changed with the "cs_property" section.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1048,6 +1048,31 @@ Default value: `absent`
 
 The corosync resource primitive to be cloned.
 
+##### `promotable`
+
+Valid values: `true`, `false`, `absent`
+
+If true, clone instances can perform a special role that Pacemaker will manage via the resource agent’s
+promote and demote actions. The resource agent must support these actions. Allowed values: false, true
+
+Default value: `absent`
+
+##### `promoted_max`
+
+Valid values: `%r{\d+}`, `absent`
+
+If promotable is true, the number of instances that can be promoted at one time across the entire cluster
+
+Default value: `absent`
+
+##### `promoted_node_max`
+
+Valid values: `%r{\d+}`, `absent`
+
+If promotable is true and globally-unique is false, the number of clone instances can be promoted at one time on a single node
+
+Default value: `absent`
+
 #### Parameters
 
 The following parameters are available in the `cs_clone` type.

--- a/lib/puppet/provider/cs_clone/crm.rb
+++ b/lib/puppet/provider/cs_clone/crm.rb
@@ -33,14 +33,17 @@ Puppet::Type.type(:cs_clone).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
       items = nvpairs_to_hash(e.elements['meta_attributes'])
 
       clone_instance = {
-        name: e.attributes['id'],
-        ensure: :present,
-        clone_max: items['clone-max'],
-        clone_node_max: items['clone-node-max'],
-        notify_clones: items['notify'],
-        globally_unique: items['globally-unique'],
-        ordered: items['ordered'],
-        interleave: items['interleave'],
+        name:              e.attributes['id'],
+        ensure:            :present,
+        clone_max:         items['clone-max'],
+        clone_node_max:    items['clone-node-max'],
+        notify_clones:     items['notify'],
+        globally_unique:   items['globally-unique'],
+        ordered:           items['ordered'],
+        interleave:        items['interleave'],
+        promotable:        items['promotable'],
+        promoted_max:      items['promoted-max'],
+        promoted_node_max: items['promoted-node-max'],
         existing_resource: :true
       }
 
@@ -56,16 +59,19 @@ Puppet::Type.type(:cs_clone).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
   # of actually doing the work.
   def create
     @property_hash = {
-      name: @resource[:name],
-      ensure: :present,
-      primitive: @resource[:primitive],
-      clone_max: @resource[:clone_max],
-      clone_node_max: @resource[:clone_node_max],
-      notify_clones: @resource[:notify_clones],
-      globally_unique: @resource[:globally_unique],
-      ordered: @resource[:ordered],
-      interleave: @resource[:interleave],
-      cib: @resource[:cib],
+      name:              @resource[:name],
+      ensure:            :present,
+      primitive:         @resource[:primitive],
+      clone_max:         @resource[:clone_max],
+      clone_node_max:    @resource[:clone_node_max],
+      notify_clones:     @resource[:notify_clones],
+      globally_unique:   @resource[:globally_unique],
+      ordered:           @resource[:ordered],
+      interleave:        @resource[:interleave],
+      cib:               @resource[:cib],
+      promotable:        @resource[:promotable],
+      promoted_max:      @resource[:promoted_max],
+      promoted_node_max: @resource[:promoted_node_max],
       existing_resource: :false
     }
   end
@@ -104,7 +110,10 @@ Puppet::Type.type(:cs_clone).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
       notify_clones: 'notify',
       globally_unique: 'globally-unique',
       ordered: 'ordered',
-      interleave: 'interleave'
+      interleave: 'interleave',
+      promotable: 'promotable',
+      promoted_max: 'promoted-max',
+      promoted_node_max: 'promoted-node-max'
     }.each do |property, clone_property|
       meta << "#{clone_property}=#{@resource.should(property)}" unless @resource.should(property) == :absent
     end

--- a/lib/puppet/provider/cs_clone/pcs.rb
+++ b/lib/puppet/provider/cs_clone/pcs.rb
@@ -45,14 +45,17 @@ Puppet::Type.type(:cs_clone).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync:
       items = nvpairs_to_hash(e.elements['meta_attributes'])
 
       clone_instance = {
-        name: e.attributes['id'],
-        ensure: :present,
-        clone_max: items['clone-max'],
-        clone_node_max: items['clone-node-max'],
-        notify_clones: items['notify'],
-        globally_unique: items['globally-unique'],
-        ordered: items['ordered'],
-        interleave: items['interleave']
+        name:              e.attributes['id'],
+        ensure:            :present,
+        clone_max:         items['clone-max'],
+        clone_node_max:    items['clone-node-max'],
+        notify_clones:     items['notify'],
+        globally_unique:   items['globally-unique'],
+        ordered:           items['ordered'],
+        interleave:        items['interleave'],
+        promotable:        items['promotable'],
+        promoted_max:      items['promoted-max'],
+        promoted_node_max: items['promoted-node-max']
       }
 
       if e.elements['primitive']
@@ -76,16 +79,19 @@ Puppet::Type.type(:cs_clone).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync:
   # of actually doing the work.
   def create
     @property_hash = {
-      name: @resource[:name],
-      ensure: :present,
-      primitive: @resource[:primitive],
-      group: @resource[:group],
-      clone_max: @resource[:clone_max],
-      clone_node_max: @resource[:clone_node_max],
-      notify_clones: @resource[:notify_clones],
-      globally_unique: @resource[:globally_unique],
-      ordered: @resource[:ordered],
-      interleave: @resource[:interleave]
+      name:              @resource[:name],
+      ensure:            :present,
+      primitive:         @resource[:primitive],
+      group:             @resource[:group],
+      clone_max:         @resource[:clone_max],
+      clone_node_max:    @resource[:clone_node_max],
+      notify_clones:     @resource[:notify_clones],
+      globally_unique:   @resource[:globally_unique],
+      ordered:           @resource[:ordered],
+      interleave:        @resource[:interleave],
+      promotable:        @resource[:promotable],
+      promoted_max:      @resource[:promoted_max],
+      promoted_node_max: @resource[:promoted_node_max]
     }
   end
 
@@ -128,7 +134,10 @@ Puppet::Type.type(:cs_clone).provide(:pcs, parent: PuppetX::Voxpupuli::Corosync:
       notify_clones: 'notify',
       globally_unique: 'globally-unique',
       ordered: 'ordered',
-      interleave: 'interleave'
+      interleave: 'interleave',
+      promotable: 'promotable',
+      promoted_max: 'promoted-max',
+      promoted_node_max: 'promoted-node-max'
     }.each do |property, clone_property|
       cmd << "#{clone_property}=#{@resource.should(property)}" unless @resource.should(property) == :absent
     end

--- a/lib/puppet/type/cs_clone.rb
+++ b/lib/puppet/type/cs_clone.rb
@@ -78,6 +78,31 @@ Puppet::Type.newtype(:cs_clone) do
     defaultto :absent
   end
 
+  newproperty(:promotable) do
+    desc 'If true, clone instances can perform a special role that Pacemaker will manage via the resource agent’s
+      promote and demote actions. The resource agent must support these actions. Allowed values: false, true'
+
+    newvalues(:true, :false, :absent)
+
+    defaultto :absent
+  end
+
+  newproperty(:promoted_max) do
+    desc 'If promotable is true, the number of instances that can be promoted at one time across the entire cluster'
+
+    newvalues(%r{\d+}, :absent)
+
+    defaultto :absent
+  end
+
+  newproperty(:promoted_node_max) do
+    desc 'If promotable is true and globally-unique is false, the number of clone instances can be promoted at one time on a single node'
+
+    newvalues(%r{\d+}, :absent)
+
+    defaultto :absent
+  end
+
   newparam(:cib) do
     desc "Corosync applies its configuration immediately. Using a CIB allows
       you to group multiple primitives and relationships to be applied at

--- a/spec/acceptance/cs_clone_spec.rb
+++ b/spec/acceptance/cs_clone_spec.rb
@@ -120,14 +120,17 @@ NWyN0RsTXFaqowV1/HSyvfD7LoF/CrmN5gOAM3Ierv/Ti9uqGVhdGBd/kw=='
         it 'creates the clone' do
           pp = <<-EOS
          cs_clone { 'duncan_vip_complex_clone_#{type}':
-           ensure          => present,
-           #{type}         => '#{property_value}',
-           clone_max       => 42,
-           notify_clones   => false,
-           clone_node_max  => 2,
-           globally_unique => true,
-           ordered         => false,
-           interleave      => false,
+           ensure            => present,
+           #{type}           => '#{property_value}',
+           clone_max         => 42,
+           notify_clones     => false,
+           clone_node_max    => 2,
+           globally_unique   => true,
+           ordered           => false,
+           interleave        => false,
+           promotable        => false,
+           promoted_max      => 5,
+           promoted_node_max => 2,
          }
           EOS
           apply_manifest(pp, catch_failures: true, debug: false, trace: true)
@@ -178,17 +181,38 @@ NWyN0RsTXFaqowV1/HSyvfD7LoF/CrmN5gOAM3Ierv/Ti9uqGVhdGBd/kw=='
           end
         end
 
+        it 'sets promotable' do
+          shell(fetch_value_command('promotable')) do |r|
+            expect(r.stdout).to match(%r{value="false"})
+          end
+        end
+
+        it 'sets promoted_max' do
+          shell(fetch_value_command('promoted-max')) do |r|
+            expect(r.stdout).to match(%r{value="5"})
+          end
+        end
+
+        it 'sets promoted_node_max' do
+          shell(fetch_value_command('promoted-node-max')) do |r|
+            expect(r.stdout).to match(%r{value="2"})
+          end
+        end
+
         it 'changes the clone' do
           pp = <<-EOS
          cs_clone { 'duncan_vip_complex_clone_#{type}':
-           ensure          => present,
-           #{type}         => '#{property_value}',
-           clone_max       => 43,
-           clone_node_max  => 1,
-           notify_clones   => true,
-           globally_unique => false,
-           ordered         => true,
-           interleave      => true,
+           ensure            => present,
+           #{type}           => '#{property_value}',
+           clone_max         => 43,
+           clone_node_max    => 1,
+           notify_clones     => true,
+           globally_unique   => false,
+           ordered           => true,
+           interleave        => true,
+           promotable        => true,
+           promoted_max      => 6,
+           promoted_node_max => 1,
          }
           EOS
           apply_manifest(pp, catch_failures: true, debug: false, trace: true)
@@ -232,6 +256,24 @@ NWyN0RsTXFaqowV1/HSyvfD7LoF/CrmN5gOAM3Ierv/Ti9uqGVhdGBd/kw=='
         it 'changes interleave' do
           shell(fetch_value_command('interleave')) do |r|
             expect(r.stdout).to match(%r{value="true"})
+          end
+        end
+
+        it 'sets promotable' do
+          shell(fetch_value_command('promotable')) do |r|
+            expect(r.stdout).to match(%r{value="true"})
+          end
+        end
+
+        it 'sets promoted_max' do
+          shell(fetch_value_command('promoted-max')) do |r|
+            expect(r.stdout).to match(%r{value="6"})
+          end
+        end
+
+        it 'sets promoted_node_max' do
+          shell(fetch_value_command('promoted-node-max')) do |r|
+            expect(r.stdout).to match(%r{value="1"})
           end
         end
 
@@ -285,6 +327,24 @@ NWyN0RsTXFaqowV1/HSyvfD7LoF/CrmN5gOAM3Ierv/Ti9uqGVhdGBd/kw=='
         it 'keeps interleave' do
           shell(fetch_value_command('interleave')) do |r|
             expect(r.stdout).to match(%r{value="true"})
+          end
+        end
+
+        it 'deletes promotable' do
+          assert_raises(Beaker::Host::CommandFailure) do
+            shell(fetch_value_command('promotable'))
+          end
+        end
+
+        it 'deletes promoted-max' do
+          assert_raises(Beaker::Host::CommandFailure) do
+            shell(fetch_value_command('promoted-max'))
+          end
+        end
+
+        it 'deletes promoted-node-max' do
+          assert_raises(Beaker::Host::CommandFailure) do
+            shell(fetch_value_command('promoted-node-max'))
           end
         end
       end

--- a/spec/unit/puppet/provider/cs_clone_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_crm_spec.rb
@@ -193,5 +193,23 @@ describe Puppet::Type.type(:cs_clone).provider(:crm) do
       expect_update(%r{\sinterleave=true})
       instance.flush
     end
+
+    it 'sets promotable' do
+      instance.resource[:interleave] = :true
+      expect_update(%r{\spromotable=true})
+      instance.flush
+    end
+
+    it 'sets max promoted' do
+      instance.resource[:promoted_max] = 3
+      expect_update(%r{\spromoted-max=3})
+      instance.flush
+    end
+
+    it 'sets max node promoted' do
+      instance.resource[:promoted_node_max] = 3
+      expect_update(%r{\spromoted-node-max=3})
+      instance.flush
+    end
   end
 end

--- a/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
@@ -178,6 +178,24 @@ describe Puppet::Type.type(:cs_clone).provider(:pcs) do
       expect_commands(%r{interleave=true})
       instance.flush
     end
+
+    it 'sets promotable' do
+      instance.resource[:promotable] = :true
+      expect_commands(%r{promotable=true})
+      instance.flush
+    end
+
+    it 'sets max promoted' do
+      instance.resource[:promotable_max] = 3
+      expect_commands(%r{promotable-max=3})
+      instance.flush
+    end
+
+    it 'sets max node promotable' do
+      instance.resource[:promotable_node_max] = 3
+      expect_commands(%r{promotable-node-max=3})
+      instance.flush
+    end
   end
 
   context 'when changing clone id' do

--- a/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
@@ -186,14 +186,14 @@ describe Puppet::Type.type(:cs_clone).provider(:pcs) do
     end
 
     it 'sets max promoted' do
-      instance.resource[:promotable_max] = 3
-      expect_commands(%r{promotable-max=3})
+      instance.resource[:promoted_max] = 3
+      expect_commands(%r{promoted-max=3})
       instance.flush
     end
 
     it 'sets max node promotable' do
-      instance.resource[:promotable_node_max] = 3
-      expect_commands(%r{promotable-node-max=3})
+      instance.resource[:promoted_node_max] = 3
+      expect_commands(%r{promoted-node-max=3})
       instance.flush
     end
   end

--- a/spec/unit/puppet/type/cs_clone_spec.rb
+++ b/spec/unit/puppet/type/cs_clone_spec.rb
@@ -30,7 +30,7 @@ describe Puppet::Type.type(:cs_clone) do
     end
 
     %i[primitive clone_max clone_node_max notify_clones globally_unique
-       ordered interleave].each do |property|
+       ordered interleave promotable promoted_max promoted_node_max].each do |property|
       it "has a #{property} property" do
         expect(subject).to be_validproperty(property)
       end
@@ -42,7 +42,7 @@ describe Puppet::Type.type(:cs_clone) do
   end
 
   describe 'when validating attributes' do
-    %i[notify_clones globally_unique ordered interleave].each do |attribute|
+    %i[notify_clones globally_unique ordered interleave promotable].each do |attribute|
       it "validates that the #{attribute} attribute can be true/false" do
         [true, false].each do |value|
           expect(subject.new(


### PR DESCRIPTION
Add the attributes promotable, promoted_max and promoted_node_max to the cs_clone resource.

The cs_clone resource now contains all options present in the pacemaker documentation: the https://www.clusterlabs.org/pacemaker/doc/2.1/Pacemaker_Explained/singlehtml/index.html#clone-options

#### Pull Request (PR) description

This pr add the parameters for managing promotable resources again, but now with the cs_clone resource instead of the cs_primary resource after that those were removed in PR #499.

#### This Pull Request (PR) fixes the following issues

Fixes #523

The required code changes in puppet to apply these changes are the following for managing a Redis Leader Follower cluster

Old setup before #499:

```puppet
cs_primitive { 'redis':
  primitive_class => 'ocf',
  provided_by     => 'heartbeat',
  primitive_type  => 'redis',
  promotable      => true,
  operations      => [
    {
      'monitor' => {
        'interval' => '1s',
        'role'     => 'Master',
        'timeout'  => '40s',
        'on-fail'  => 'restart'
      }
    }, {
      'monitor' => {
        'interval' => '2s',
        'role'     => 'Slave',
        'timeout'  => '40s',
        'on-fail'  => 'restart'
      }
    },
  ],
  ms_metadata     =>  {
    'master-max'      => 1,
    'master-node-max' => 1,
    'clone-node-max'  => 1,
    'target-role'     => 'Master',
    'is-managed'      => true,
    'notify'          => true,
  },
}
```

Puppet code after this PR:

```puppet
cs_primitive { 'redis':
  ensure          => present,
  primitive_class => 'ocf',
  provided_by     => 'heartbeat',
  primitive_type  => 'redis',
  operations      => [
    {
      'demote'  => {
        'interval' => '0s',
        'timeout'  => '90'
      }
    }, {
      'monitor' => {
        'interval' => '1s',
        'role'     => 'Promoted',
        'timeout'  => '40s',
        'on-fail'  => 'restart'
      }
    }, {
      'monitor' => {
        'interval' => '2s',
        'role'     => 'Unpromoted',
        'timeout'  => '40s',
        'on-fail'  => 'restart'
      }
    }, {
      'notify' => {
        'interval' => '0s',
        'timeout'  => '90',
      }
    }, {
      'promote' => {
        'interval' => '0s',
        'timeout'  => '90',
      }
    }, {
      'reload' => {
        'interval' => '0s',
        'timeout'  => '30',
      }
    }, {
      'start' => {
        'interval' => '0s',
        'timeout'  => '240',
      }
    }, {
      'stop' => {
        'interval' => '0s',
        'timeout'  => '100',
      }
    },
  ],
}

cs_clone { 'redis-clone':
  ensure          => present,
  primitive       => 'redis',
  clone_max       => 2,
  clone_node_max  => 1,
  promotable      => true,
  promoted_max    => 1,
  promoted_node_max => 1,
  notify_clones   => true,
}
```

This will create a very simular setup, but master/slave has been renamed to promoted/unpromoted in the pacemaker documentation.
