### PR TITLE
pcsd: Switch from tokens to known-hosts file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -601,9 +601,9 @@ class corosync (
       # Attempt to authorize all members. The command will return successfully
       # if they were already authenticated so it's safe to run every time this
       # is applied.
-      # TODO - make it run only once
       exec { 'authorize_members':
         command => "${pcs_auth_command} ${node_string} ${auth_credential_string}",
+        unless  => join($quorum_members.map |$m| { "grep -q '${m}' /var/lib/pcsd/known-hosts 2>/dev/null" }, ' && '),
         path    => $exec_path,
         require => [
           Service['pcsd'],
@@ -646,7 +646,7 @@ class corosync (
 
       # Authorize the quorum device via PCS so we can execute the configuration
       $token_prefix = 'test 0 -ne $(grep'
-      $token_suffix = '/var/lib/pcsd/tokens >/dev/null 2>&1; echo $?)'
+      $token_suffix = '/var/lib/pcsd/known-hosts >/dev/null 2>&1; echo $?)'
       $qdevice_token_check = "${token_prefix} ${quorum_device_host} ${token_suffix}"
 
       $quorum_device_password = $sensitive_quorum_device_password.unwrap

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -845,6 +845,7 @@ describe 'corosync' do
               is_expected.to contain_exec('authorize_members').with(
                 command: "pcs #{auth_command} 192.168.0.10 192.168.0.12 192.168.0.13 -u hacluster -p some-secret-sauce",
                 path: '/sbin:/bin:/usr/sbin:/usr/bin',
+                unless: "grep -q '192.168.0.10' /var/lib/pcsd/known-hosts 2>/dev/null && grep -q '192.168.0.12' /var/lib/pcsd/known-hosts 2>/dev/null && grep -q '192.168.0.13' /var/lib/pcsd/known-hosts 2>/dev/null",
                 require: [
                   'Service[pcsd]',
                   'User[hacluster]'
@@ -1030,7 +1031,7 @@ describe 'corosync' do
                 is_expected.to contain_exec('authorize_qdevice').with(
                   command: "pcs #{auth_command} quorum1.test.org -u hacluster -p quorum-secret-password",
                   path: '/sbin:/bin:/usr/sbin:/usr/bin',
-                  onlyif: 'test 0 -ne $(grep quorum1.test.org /var/lib/pcsd/tokens >/dev/null 2>&1; echo $?)',
+                  onlyif: 'test 0 -ne $(grep quorum1.test.org /var/lib/pcsd/known-hosts >/dev/null 2>&1; echo $?)',
                   require: [
                     'Package[corosync-qdevice]',
                     'Exec[authorize_members]',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
New pcs version stores tokens into _known-hosts_ file instead of `/var/lib/pcsd/tokens`

> This JSON file stores information about hosts known to the local pcsd which are used to login to remote instances of pcsd. Stored information include host addresses, pcsd ports and **authentication tokens**.

https://manpages.debian.org/testing/pcs/pcsd.8.en.html

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
