### PR TITLE
Remove old env variable / require corosync 3

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -192,7 +192,7 @@ Data type: `String[1]`
 
 
 
-Default value: `'/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'`
+Default value: `'/usr/sbin/corosync -t -c %'`
 
 ##### <a name="-corosync--threads"></a>`threads`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -399,7 +399,7 @@ class corosync (
   Optional[String[1]] $ip_version                                       = undef,
   Optional[Enum['yes', 'no']] $clear_node_high_bit                      = undef,
   Optional[Integer] $max_messages                                       = undef,
-  String[1] $config_validate_cmd                                        = '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t',
+  String[1] $config_validate_cmd                                        = '/usr/sbin/corosync -t -c %',
   Boolean $test_corosync_config                                         = $corosync::params::test_corosync_config,
   Optional[Variant[Stdlib::Absolutepath, Enum['off']]] $watchdog_device = undef,
   Enum['pcs', 'crm'] $provider                                          = 'pcs',

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -19,7 +19,7 @@ describe 'corosync' do
 
     it 'validates the corosync configuration' do
       is_expected.to contain_file('/etc/corosync/corosync.conf').with_validate_cmd(
-        '/usr/bin/env COROSYNC_MAIN_CONFIG_FILE=% /usr/sbin/corosync -t'
+        '/usr/sbin/corosync -t -c %'
       )
     end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
From corosync 3.0.0. there are not any environment variables. Thus the validate_cmd for the corosync.conf is not correct.

More info https://github.com/corosync/corosync/wiki/Corosync-3.0.0-Release-Notes?utm_source=chatgpt.com :
> env COROSYNC_MAIN_CONFIG_FILE - Replaced by "-c" option. This also affects uidgid.d location.


 
#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
