### PR TITLE
replace `String#concat` with `Array#push` to avoid frozen string violation

### DIFF
--- a/lib/puppet/provider/cs_clone/crm.rb
+++ b/lib/puppet/provider/cs_clone/crm.rb
@@ -102,10 +102,10 @@ Puppet::Type.type(:cs_clone).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
     else
       raise Puppet::Error, 'No primitive or group'
     end
-    updated = 'clone '
+    updated = ['clone ']
     updated << "#{@resource.value(:name)} "
     updated << "#{target} "
-    meta = []
+    meta = ['meta']
     {
       clone_max: 'clone-max',
       clone_node_max: 'clone-node-max',
@@ -119,10 +119,11 @@ Puppet::Type.type(:cs_clone).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
     }.each do |property, clone_property|
       meta << "#{clone_property}=#{@resource.should(property)}" unless @resource.should(property) == :absent
     end
-    updated << 'meta ' << meta.join(' ') unless meta.empty?
-    debug "Update: #{updated}"
+    updated << meta.join(' ') unless meta.length == 1
+    updated_s = updated.join
+    debug "Update: #{updated_s}"
     Tempfile.open('puppet_crm_update') do |tmpfile|
-      tmpfile.write(updated)
+      tmpfile.write(updated_s)
       tmpfile.flush
       cmd = [command(:crm), 'configure', 'load', 'update', tmpfile.path.to_s]
       self.class.run_command_in_cib(cmd, @resource.value(:cib))

--- a/lib/puppet/provider/cs_colocation/crm.rb
+++ b/lib/puppet/provider/cs_colocation/crm.rb
@@ -152,11 +152,12 @@ Puppet::Type.type(:cs_colocation).provide(:crm, parent: PuppetX::Voxpupuli::Coro
                  else
                    @property_hash[:primitives]
                  end
-    updated = 'colocation '
+    updated = ['colocation ']
     updated << "#{@property_hash[:name]} #{@property_hash[:score]}: #{primitives.join(' ')}"
-    debug("Loading update: #{updated}")
+    updated_s = updated.join
+    debug("Loading update: #{updated_s}")
     Tempfile.open('puppet_crm_update') do |tmpfile|
-      tmpfile.write(updated)
+      tmpfile.write(updated_s)
       tmpfile.flush
       self.class.run_command_in_cib(['crm', 'configure', 'load', 'update', tmpfile.path.to_s], @resource[:cib])
     end

--- a/lib/puppet/provider/cs_group/crm.rb
+++ b/lib/puppet/provider/cs_group/crm.rb
@@ -89,11 +89,12 @@ Puppet::Type.type(:cs_group).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
   def flush
     return if @property_hash.empty?
 
-    updated = 'group '
+    updated = ['group ']
     updated << "#{@property_hash[:name]} #{Array(@property_hash[:primitives]).join(' ')}"
-    debug("Loading update: #{updated}")
+    updated_s = updated.join
+    debug("Loading update: #{updated_s}")
     Tempfile.open('puppet_crm_update') do |tmpfile|
-      tmpfile.write(updated)
+      tmpfile.write(updated_s)
       tmpfile.flush
       cmd = [command(:crm), 'configure', 'load', 'update', tmpfile.path.to_s]
       self.class.run_command_in_cib(cmd, @resource[:cib])

--- a/lib/puppet/provider/cs_location/crm.rb
+++ b/lib/puppet/provider/cs_location/crm.rb
@@ -100,7 +100,7 @@ Puppet::Type.type(:cs_location).provide(:crm, parent: PuppetX::Voxpupuli::Corosy
   def flush
     return if @property_hash.empty?
 
-    updated = "location #{@property_hash[:name]} #{@property_hash[:primitive]}"
+    updated = ["location #{@property_hash[:name]} #{@property_hash[:primitive]}"]
 
     updated << " resource-discovery=#{@property_hash[:resource_discovery]}" if feature?(:discovery) && !@property_hash[:resource_discovery].nil?
 
@@ -120,9 +120,10 @@ Puppet::Type.type(:cs_location).provide(:crm, parent: PuppetX::Voxpupuli::Corosy
       updated << " #{score}: #{expression.join(' ')}"
     end
 
-    debug("Loading update: #{updated}")
+    updated_s = updated.join
+    debug("Loading update: #{updated_s}")
     Tempfile.open('puppet_crm_update') do |tmpfile|
-      tmpfile.write(updated)
+      tmpfile.write(updated_s)
       tmpfile.flush
       self.class.run_command_in_cib(['crm', 'configure', 'load', 'update', tmpfile.path.to_s], @resource[:cib])
     end

--- a/lib/puppet/provider/cs_order/crm.rb
+++ b/lib/puppet/provider/cs_order/crm.rb
@@ -100,7 +100,7 @@ Puppet::Type.type(:cs_order).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
   def flush
     return if @property_hash.empty?
 
-    updated = 'order '
+    updated = ['order ']
     updated << "#{@property_hash[:name]} "
     if @property_hash[:score]
       updated << "#{@property_hash[:score]}: "
@@ -108,9 +108,10 @@ Puppet::Type.type(:cs_order).provide(:crm, parent: PuppetX::Voxpupuli::Corosync:
       updated << "#{@property_hash[:kind]}: "
     end
     updated << "#{@property_hash[:first]} #{@property_hash[:second]} symmetrical=#{@property_hash[:symmetrical]}"
-    debug("Loading update: #{updated}")
+    updated_s = updated.join
+    debug("Loading update: #{updated_s}")
     Tempfile.open('puppet_crm_update') do |tmpfile|
-      tmpfile.write(updated)
+      tmpfile.write(updated_s)
       tmpfile.flush
       self.class.run_command_in_cib([command(:crm), 'configure', 'load', 'update', tmpfile.path.to_s], @resource[:cib])
     end

--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -152,7 +152,7 @@ Puppet::Type.type(:cs_primitive).provide(:crm, parent: PuppetX::Voxpupuli::Coros
     return if @property_hash.empty?
 
     unless @property_hash[:operations].empty?
-      operations = ''
+      operations = []
       @property_hash[:operations].each do |o|
         op_name = o.keys.first
         operations << "op #{op_name} "
@@ -167,34 +167,35 @@ Puppet::Type.type(:cs_primitive).provide(:crm, parent: PuppetX::Voxpupuli::Coros
       end
     end
     unless @property_hash[:parameters].empty?
-      parameters = 'params '
+      parameters = ['params ']
       @property_hash[:parameters].each_pair do |k, v|
         parameters << "'#{k}=#{v}' "
       end
     end
     unless @property_hash[:utilization].empty?
-      utilization = 'utilization '
+      utilization = ['utilization ']
       @property_hash[:utilization].each_pair do |k, v|
         utilization << "#{k}=#{v} "
       end
     end
     unless @property_hash[:metadata].empty?
-      metadatas = 'meta '
+      metadatas = ['meta ']
       @property_hash[:metadata].each_pair do |k, v|
         metadatas << "#{k}=#{v} "
       end
     end
-    updated = 'primitive '
+    updated = ['primitive ']
     updated << "#{@property_hash[:name]} #{@property_hash[:primitive_class]}:"
     updated << "#{@property_hash[:provided_by]}:" if @property_hash[:provided_by]
     updated << "#{@property_hash[:primitive_type]} "
-    updated << "#{operations} " unless operations.nil?
-    updated << "#{parameters} " unless parameters.nil?
-    updated << "#{utilization} " unless utilization.nil?
-    updated << "#{metadatas} " unless metadatas.nil?
-    debug("Loading update: #{updated}")
+    updated.concat(operations) unless operations.nil?
+    updated.concat(parameters) unless parameters.nil?
+    updated.concat(utilization) unless utilization.nil?
+    updated.concat(metadatas) unless metadatas.nil?
+    updated_s = updated.join
+    debug("Loading update: #{updated_s}")
     Tempfile.open('puppet_crm_update') do |tmpfile|
-      tmpfile.write(updated)
+      tmpfile.write(updated_s)
       tmpfile.flush
       cmd = ['crm', '-F', 'configure', 'load', 'update', tmpfile.path.to_s]
       self.class.run_command_in_cib(cmd, @resource[:cib])

--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -181,17 +181,19 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, parent: PuppetX::Voxpupuli::Coros
     # The resource_type variable is used to check if one of the class,
     # provider or type has changed. Since stonith resources have a special
     # command they do not include a provider or class in their type name
-    resource_type = "#{@property_hash[:primitive_class]}:"
+    resource_type = ["#{@property_hash[:primitive_class]}:"]
     resource_type << "#{@property_hash[:provided_by]}:" if @property_hash[:provided_by]
     resource_type << @property_hash[:primitive_type].to_s
+    resource_type = resource_type.join
 
     # We destroy the resource if it's type, class or provider has changed
     unless @property_hash[:existing_resource] == :false
-      existing_resource_type = "#{@property_hash[:existing_primitive_class]}:"
+      existing_resource_type = ["#{@property_hash[:existing_primitive_class]}:"]
       existing_resource_type << "#{@property_hash[:existing_provided_by]}:" if @property_hash[:existing_provided_by]
       existing_resource_type << @property_hash[:existing_primitive_type].to_s
+      existing_resource_type = existing_resource_type.join
 
-      if existing_resource_type != resource_type
+      unless existing_resource_type == resource_type
         debug('Removing primitive')
         self.class.run_command_in_cib([command(:pcs), pcs_subcommand, 'unclone', @property_hash[:name].to_s], @resource[:cib], false)
         self.class.run_command_in_cib([command(:pcs), pcs_subcommand, 'delete', '--force', @property_hash[:name].to_s], @resource[:cib])
@@ -201,11 +203,11 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, parent: PuppetX::Voxpupuli::Coros
 
     if @property_hash[:existing_resource] == :false || force_reinstall == :true
       cmd = [command(:pcs), pcs_subcommand, 'create', '--force', '--no-default-ops', @property_hash[:name].to_s]
-      cmd << resource_type
-      cmd += parameters unless parameters.nil?
-      cmd += operations unless operations.nil?
-      cmd += utilization unless utilization.nil?
-      cmd += metadatas unless metadatas.nil?
+      cmd.push(resource_type)
+      cmd.concat(parameters) unless parameters.nil?
+      cmd.concat(operations) unless operations.nil?
+      cmd.concat(utilization) unless utilization.nil?
+      cmd.concat(metadatas) unless metadatas.nil?
       # default_op = { 'monitor' => { 'interval' => '60s' } }
       # unless @property_hash[:operations].include?(default_op)
       #   cmd = [command(:pcs), pcs_subcommand, 'op', 'remove', (@property_hash[:name]).to_s, 'monitor', 'interval=60s']
@@ -221,10 +223,10 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, parent: PuppetX::Voxpupuli::Coros
         self.class.run_command_in_cib(cmd, @resource[:cib])
       end
       cmd = [command(:pcs), pcs_subcommand, 'update', @property_hash[:name].to_s]
-      cmd += parameters unless parameters.nil?
-      cmd += operations unless operations.nil?
-      cmd += utilization unless utilization.nil?
-      cmd += metadatas unless metadatas.nil?
+      cmd.concat(parameters) unless parameters.nil?
+      cmd.concat(operations) unless operations.nil?
+      cmd.concat(utilization) unless utilization.nil?
+      cmd.concat(metadatas) unless metadatas.nil?
       self.class.run_command_in_cib(cmd, @resource[:cib])
     end
   end

--- a/lib/puppet/type/cs_primitive.rb
+++ b/lib/puppet/type/cs_primitive.rb
@@ -172,14 +172,14 @@ Puppet::Type.newtype(:cs_primitive) do
       same_ops = (currentvalue + newvalue).uniq - new_ops - deleted_ops
       message = []
       unless new_ops.empty?
-        m = "#{new_ops.size} added:"
-        new_ops.each { |n| m << ' ' << op_to_s(n) }
-        message << m
+        m = ["#{new_ops.size} added:"]
+        new_ops.each { |n| m << op_to_s(n) }
+        message << m.join(' ')
       end
       unless deleted_ops.empty?
-        m = "#{deleted_ops.size} removed:"
-        deleted_ops.each { |n| m << ' ' << op_to_s(n) }
-        message << m
+        m = ["#{deleted_ops.size} removed:"]
+        deleted_ops.each { |n| m << op_to_s(n) }
+        message << m.join(' ')
       end
       message << "#{same_ops.size} kept" unless same_ops.empty?
       message.join ' / '


### PR DESCRIPTION
#### Pull Request (PR) description
with Ruby 3.0 strings are frozen by default causing the catalog compiler to throw errors when one of the native corosync module types is used.

this change replaces the use of the string concatenation operator with an array that gets joined into a string for further use.

the functionality and data passed to external systems should remain unchanged, making this change backwards compatible.

#### This Pull Request (PR) fixes the following issues

n/a