### PR TITLE
cs_clone: short-circuit validation if resource was provider-generated

### DIFF
--- a/lib/puppet/type/cs_clone.rb
+++ b/lib/puppet/type/cs_clone.rb
@@ -143,6 +143,11 @@ Puppet::Type.newtype(:cs_clone) do
   validate do
     return if self[:ensure] == :absent
 
+    # If resource was generated dynamically by the provider (e.g., puppet resource or purge), short-circuit validation.
+    has_provider_properties = provider&.instance_variable_defined?(:@property_hash) &&
+                              provider&.instance_variable_get(:@property_hash)&.any?
+    return if @sensitive_parameters.nil? || has_provider_properties
+
     mandatory_single_properties = %i[primitive group]
     has_should = mandatory_single_properties.select { |prop| should(prop) }
     raise Puppet::Error, "You cannot specify #{has_should.join(' and ')} on this type (only one)" if has_should.length > 1


### PR DESCRIPTION
#### Pull Request (PR) description
Validation will always fail for provider-generated resource otherwise, as validation for "either primitive or group must be set" always fails, as they are not set as intended (`should`) state.

Fixes resource discovery, e.g. via:
```shell
puppet resource cs_clone
```
and hence also pruning of unmanaged resources, e.g. via:
```puppet
resources { 'cs_clone':
   purge   => true,
}
```
